### PR TITLE
[FEAT] Global / Swagger 설정, ApiResponse, ExceptionHandler 생성 및 응답 통일

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 <br>
 
----
+## ERD
+<img width="6484" height="4226" alt="weady-erd" src="https://github.com/user-attachments/assets/8b72e272-3429-4563-8cca-4a95b33ac2b3" />
+
+
+<br>
+
 
 <br>
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,20 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// 테스트 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/weady/weady/common/apiResponse/ApiErrorResponse.java
+++ b/src/main/java/com/weady/weady/common/apiResponse/ApiErrorResponse.java
@@ -1,0 +1,23 @@
+package com.weady.weady.common.apiResponse;
+
+import com.weady.weady.common.error.errorCode.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ApiErrorResponse extends ApiResponse<Void> {
+
+    // 실패 시에는 생성자를 통해 code와 message를 직접 입력받습니다.
+    private ApiErrorResponse(int code, String message) {
+        super(code, message, null);
+    }
+
+    // ErrorCode Enum을 사용하는 경우 (가장 권장)
+    public static ApiErrorResponse of(ErrorCode errorCode) {
+        return new ApiErrorResponse(errorCode.getCode(), errorCode.getMessage());
+    }
+
+    // 코드를 직접 지정하는 경우
+    public static ApiErrorResponse of(int code, String message) {
+        return new ApiErrorResponse(code, message);
+    }
+}

--- a/src/main/java/com/weady/weady/common/apiResponse/ApiResponse.java
+++ b/src/main/java/com/weady/weady/common/apiResponse/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.weady.weady.common.apiResponse;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 모든 응답의 기본 구조를 정의하는 추상 클래스
+// protected 생성자를 통해 new 키워드로 직접 인스턴스 생성을 막고, 정적 팩토리 메서드를 사용하도록 유도합니다.
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+// 성공 응답에서는 data 필드가 null일 수 없으므로, 실패 응답에서만 null이 될 수 있습니다.
+// JsonInclude.Include.NON_NULL은 null인 필드를 JSON으로 변환할 때 제외시킵니다.
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class ApiResponse<T> {
+
+    protected int code;
+    protected String message;
+    protected T data;
+
+    protected ApiResponse(int code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/weady/weady/common/apiResponse/ApiSuccessResponse.java
+++ b/src/main/java/com/weady/weady/common/apiResponse/ApiSuccessResponse.java
@@ -1,0 +1,29 @@
+package com.weady.weady.common.apiResponse;
+
+import lombok.Getter;
+
+@Getter
+public class ApiSuccessResponse<T> extends ApiResponse<T> {
+
+    // 성공 시에는 code와 message가 고정되므로 생성자에서 값을 지정합니다.
+    private static final int SUCCESS_CODE = 200;
+    private static final String SUCCESS_MESSAGE = "Success";
+
+    private ApiSuccessResponse(T data) {
+        super(SUCCESS_CODE, SUCCESS_MESSAGE, data);
+    }
+
+    private ApiSuccessResponse(T data, String message) {
+        super(SUCCESS_CODE, message, data);
+    }
+
+    // 정적 팩토리 메서드: 데이터만 받는 경우
+    public static <T> ApiSuccessResponse<T> of(T data) {
+        return new ApiSuccessResponse<>(data);
+    }
+
+    // 정적 팩토리 메서드: 데이터와 커스텀 메시지를 받는 경우
+    public static <T> ApiSuccessResponse<T> of(T data, String message) {
+        return new ApiSuccessResponse<>(data, message);
+    }
+}

--- a/src/main/java/com/weady/weady/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/weady/weady/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.weady.weady.common.error;
+
+import com.weady.weady.common.apiResponse.ApiErrorResponse;
+import com.weady.weady.common.error.errorCode.CommonErrorCode;
+import com.weady.weady.common.error.errorCode.ErrorCode;
+import com.weady.weady.common.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 애플리케이션 전역에서 발생하는 예외를 처리하는 클래스입니다.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * BusinessException 타입의 예외를 처리합니다.
+     * 비즈니스 로직 상에서 발생하는 모든 예측된 예외를 담당합니다.
+     */
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ApiErrorResponse> handleBusinessException(BusinessException ex) {
+        log.warn("BusinessException: {}", ex.getMessage());
+        ErrorCode errorCode = ex.getErrorCode();
+        ApiErrorResponse response = ApiErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getCode()));
+    }
+
+    /**
+     * 처리되지 않은 모든 예외를 처리합니다.
+     * 예측하지 못한 서버 오류를 담당합니다.
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiErrorResponse> handleException(Exception ex) {
+        log.error("Unhandled Exception: ", ex);
+        ApiErrorResponse response = ApiErrorResponse.of(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/weady/weady/common/error/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/AuthErrorCode.java
@@ -1,0 +1,16 @@
+package com.weady.weady.common.error.errorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    AUTHENTICATION_FAILED(401, "인증에 실패했습니다."),
+    AUTHORIZATION_FAILED(403, "접근 권한이 없습니다."),
+    INVALID_TOKEN(401, "유효하지 않은 토큰입니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/weady/weady/common/error/errorCode/CommonErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/CommonErrorCode.java
@@ -1,0 +1,16 @@
+package com.weady.weady.common.error.errorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(400, "입력 값이 올바르지 않습니다."),
+    RESOURCE_NOT_FOUND(404, "리소스를 찾을 수 없습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/weady/weady/common/error/errorCode/ErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/ErrorCode.java
@@ -1,0 +1,6 @@
+package com.weady.weady.common.error.errorCode;
+
+public interface ErrorCode {
+    int getCode();
+    String getMessage();
+}

--- a/src/main/java/com/weady/weady/common/error/errorCode/UserErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/UserErrorCode.java
@@ -1,0 +1,16 @@
+package com.weady.weady.common.error.errorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(404, "해당 사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(409, "이미 존재하는 사용자입니다."),
+    INVALID_PASSWORD(400, "비밀번호가 일치하지 않습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/weady/weady/common/error/exception/BusinessException.java
+++ b/src/main/java/com/weady/weady/common/error/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.weady.weady.common.error.exception;
+
+import com.weady.weady.common.error.errorCode.ErrorCode;
+import lombok.Getter;
+
+/**
+ * 비즈니스 로직 상의 모든 예외를 포함하는 최상위 예외 클래스입니다.
+ * 이후에 로직이 복잡해질 경우 각 도메인 별로 Exception을 쪼는 방향으로 리팩토링합니다.
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        // 부모 클래스(RuntimeException)의 생성자를 호출하여 메시지를 설정
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/weady/weady/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/weady/weady/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,51 @@
+package com.weady.weady.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwtSchemeName = "bearerAuth";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Weady API Documentation")
+                .description("Weady 프로젝트 API 명세서입니다.")
+                .version("v0.0.1");
+    }
+
+    /*
+    * 각 API 도메인 별로 그룹화하여 Swagger UI에 표시합니다.
+    * */
+    @Bean
+    public GroupedOpenApi authApi() {
+        return GroupedOpenApi.builder()
+                .group("1. 인증 API") // Swagger UI에 표시될 그룹 이름
+                .pathsToMatch("/api/v1/auth/**") // 이 그룹에 포함될 API의 URL 패턴
+                .build();
+    }
+
+    // 추후 다른 도메인 API가 추가되면 여기에 GroupedOpenApi Bean을 추가해주세요
+}

--- a/src/main/java/com/weady/weady/presentation/ResponseEntityUtil.java
+++ b/src/main/java/com/weady/weady/presentation/ResponseEntityUtil.java
@@ -1,0 +1,19 @@
+package com.weady.weady.presentation;
+
+import com.weady.weady.common.apiResponse.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityUtil {
+    public static <T> ResponseEntity<ApiResponse<T>> buildResponseEntityWithStatus(ApiResponse<T> body, HttpStatus status) {
+        return ResponseEntity.status(status).body(body);
+    }
+
+    public static <T>ResponseEntity<ApiResponse<T>> buildDefaultResponseEntity(ApiResponse<T> body) {
+        return ResponseEntity.ok(body);
+    }
+
+    public static ResponseEntity<Void> buildSimpleResponseEntity() {
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#1 

## 📝작업 내용

### Swagger
Swagger를 위한 의존성을 추가했습니다.
Swagger의 기본설정을 위해 submodule에 존재하는 applicaiton.yml 파일을 수정했습니다.

### ApiResponse
응답 통일을 위해 ApiResponse를 생성했습니다.
응답의 예시는 다음과 같습니다.

```json
{
    "code": 200,
    "message": "Success",
    "data": {
        "id": 1,
        "email": "test@example.com",
        "name": "홍길동"
    }
}
                  
```
`Controller`에서 데이터를 ApiResponse에 감쌀때는 `ApiSuccessResponse.of(userDto)` 와 같이 ApiSuccessResponse의 함수를 이용해서 감싸줍니다.

또한 응답 데이터는 Exception시의 응답과 통일하기 위해서 `ResponseEntity`로 한 번 더 감싼 뒤에 Return합니다.
ResponseEntity로 감싸는 것은 ResponseEntityUtil 클래스의 여러 static method를 각 상황에 맞게 사용합니다.

`buildResponseEntityWithStatus` method는 status와 data를 추가할 때,
`buildDefaultResponseEntity` method는 data만 추가하고 200 status를 사용할 때,
`buildSimpleResponseEntity` method는 data 없이 단순 200 status를 리턴할 때 사용합니다.

### ExceptionHandler
ErrorCode는 도메인별로 나누고, Exception은 단순하게 BusinessException 하나로 만들었습니다.
개발 초기에는 Exception을 하나씩 나누는게 조금 복잡도를 올리는 느낌이라 하나로 통합되어있는 상태에서 나중에 도메인 별로 나누는 방식으로 리팩토링 하려고합니다.
