### PR TITLE
[FEAT] Fashion / 옷차림 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/weady/weady/domain/fashion/controller/FashionController.java
+++ b/src/main/java/com/weady/weady/domain/fashion/controller/FashionController.java
@@ -1,5 +1,6 @@
 package com.weady.weady.domain.fashion.controller;
 
+import com.weady.weady.domain.fashion.dto.Response.FashionDetailResponseDto;
 import com.weady.weady.domain.fashion.dto.Response.FashionSummaryResponseDto;
 import com.weady.weady.domain.fashion.service.FashionService;
 import com.weady.weady.global.common.apiResponse.ApiResponse;
@@ -20,6 +21,13 @@ public class FashionController {
     @GetMapping("/summary")
     public ResponseEntity<ApiResponse<FashionSummaryResponseDto>> getFashionSummary() {
         FashionSummaryResponseDto response = fashionService.getFashionSummary();
+
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(response));
+    }
+
+    @GetMapping("/detail")
+    public ResponseEntity<ApiResponse<FashionDetailResponseDto>> getFashionDetail() {
+        FashionDetailResponseDto response = fashionService.getFashionDetail();
 
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(response));
     }

--- a/src/main/java/com/weady/weady/domain/fashion/dto/Response/FashionDetailResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/fashion/dto/Response/FashionDetailResponseDto.java
@@ -1,0 +1,38 @@
+package com.weady.weady.domain.fashion.dto.Response;
+
+import java.util.List;
+
+public record FashionDetailResponseDto(Long locationId,
+                                       String locationBCode,
+                                       String address1,
+                                       String address2,
+                                       String address3,
+                                       String address4,
+                                       Recommendation recommendation,
+                                       List<ChartPoint> chart,
+                                       Tags tags
+                                       ) {
+
+    public record Recommendation(int time,
+                                 float feelTmp,
+                                 Clothing clothing
+    ) {}
+
+    public record ChartPoint(int time,
+                             float feelTmp,
+                             Clothing clothing
+    ) {}
+
+    public record Clothing(String name,
+                           String imageUrl
+    ) {}
+
+    public record Tags(Tag season,
+                       Tag weather,
+                       Tag temperature
+    ) {}
+
+    public record Tag(Long id,
+                      String name
+    ) {}
+}

--- a/src/main/java/com/weady/weady/domain/fashion/service/FashionService.java
+++ b/src/main/java/com/weady/weady/domain/fashion/service/FashionService.java
@@ -1,13 +1,22 @@
 package com.weady.weady.domain.fashion.service;
 
+import com.weady.weady.domain.fashion.dto.Response.FashionDetailResponseDto;
 import com.weady.weady.domain.fashion.dto.Response.FashionSummaryResponseDto;
 import com.weady.weady.domain.fashion.entity.Fashion;
 import com.weady.weady.domain.fashion.repository.FashionRepository;
+import com.weady.weady.domain.location.entity.Location;
+import com.weady.weady.domain.location.repository.LocationRepository;
+import com.weady.weady.domain.tags.entity.SeasonTag;
+import com.weady.weady.domain.tags.entity.TemperatureTag;
+import com.weady.weady.domain.tags.entity.WeatherTag;
 import com.weady.weady.domain.user.entity.User;
 import com.weady.weady.domain.user.repository.UserRepository;
+import com.weady.weady.domain.weather.entity.DailySummary;
 import com.weady.weady.domain.weather.entity.LocationWeatherSnapshot;
+import com.weady.weady.domain.weather.repository.DailySummaryRepository;
 import com.weady.weady.domain.weather.repository.LocationWeatherSnapshotRepository;
 import com.weady.weady.global.common.error.errorCode.FashionErrorCode;
+import com.weady.weady.global.common.error.errorCode.LocationErrorCode;
 import com.weady.weady.global.common.error.errorCode.UserErrorCode;
 import com.weady.weady.global.common.error.errorCode.WeatherErrorCode;
 import com.weady.weady.global.common.error.exception.BusinessException;
@@ -17,6 +26,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +34,8 @@ public class FashionService {
     private final FashionRepository fashionRepository;
     private final LocationWeatherSnapshotRepository locationWeatherSnapshotRepository;
     private final UserRepository userRepository;
+    private final LocationRepository locationRepository;
+    private final DailySummaryRepository dailySummaryRepository;
 
     /**
      * 홈 화면에서 옷차림 요약 정보를 조회
@@ -65,4 +77,115 @@ public class FashionService {
                 fashion.getImgUrl()
         );
     }
+
+    /**
+     * 옷차림 화면에서 옷차림 상세 정보를 조회
+     * @return FashionDetailResponseDto
+     * @thorws UserErrorCode.USER_NOT_FOUND 사용자가 존재하지 않을 경우 예외를 발생
+     * @thorws WeatherErrorCode.WEATHER_SNAPSHOT_NOT_FOUND 날씨 snapshot이 존재하지 않을 경우 예외를 발생
+     * @thorws FashionErrorCode.FASHION_NOT_FOUND 체감온도에 따른 옷차림 추천이 존재하지 않을 경우 예외를 발생
+     * @thorws LocationErrorCode.LOCATION_NOT_FOUND 위치가 존재하지 않을 경우 예외를 발생
+     */
+    public FashionDetailResponseDto getFashionDetail() {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Long locationId = null;
+        if (user.getDefaultLocation() != null && user.getDefaultLocation().getLocation() != null) {
+            locationId = user.getDefaultLocation().getLocation().getId();
+        } else if (user.getNowLocation() != null) {
+            locationId = user.getNowLocation().getId();
+        }
+
+        LocalDateTime today = LocalDateTime.now();
+        int date = Integer.parseInt(today.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+        int time = today.getHour() * 100;
+
+        List<LocationWeatherSnapshot> snapshots =
+                locationWeatherSnapshotRepository.findByLocationIdAndDateOrderByTimeAsc(locationId, date);
+
+        if (snapshots.isEmpty()) {
+            throw new BusinessException(WeatherErrorCode.WEATHER_SNAPSHOT_NOT_FOUND);
+        }
+
+        LocationWeatherSnapshot currentSnapshot = snapshots.stream()
+                .filter(s -> s.getTime() == time)
+                .findFirst()
+                .orElse(snapshots.get(0));
+
+        float feelTemp = currentSnapshot.getFeelTmp();
+
+        List<Fashion> fashions = fashionRepository.findAll();
+
+        Fashion currentFashion = findFashionFor(feelTemp, fashions);;
+
+        FashionDetailResponseDto.Recommendation recommendation =
+                new FashionDetailResponseDto.Recommendation(
+                        currentSnapshot.getTime(),
+                        currentSnapshot.getFeelTmp(),
+                        toClothing(currentFashion)
+                );
+
+        List<FashionDetailResponseDto.ChartPoint> chart = snapshots.stream()
+                .map(s -> {
+                    Fashion fashion = findFashionFor(s.getFeelTmp(), fashions);
+                    return new FashionDetailResponseDto.ChartPoint(
+                            s.getTime(),
+                            s.getFeelTmp(),
+                            toClothing(fashion)
+                    );
+                })
+                .toList();
+
+        DailySummary dailySummary = dailySummaryRepository
+                .findByLocationIdAndReportDateWithTags(locationId, today.toLocalDate())
+                .orElseThrow(() -> new BusinessException(WeatherErrorCode.WEATHER_SNAPSHOT_NOT_FOUND));
+
+        FashionDetailResponseDto.Tags tags = new FashionDetailResponseDto.Tags(
+                toTag(dailySummary.getSeasonTag()),
+                toTag(dailySummary.getWeatherTag()),
+                toTag(dailySummary.getTemperatureTag())
+        );
+
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new BusinessException(LocationErrorCode.LOCATION_NOT_FOUND));
+
+        return new FashionDetailResponseDto(
+                location.getId(),
+                location.getBCode(),
+                location.getAddress1(),
+                location.getAddress2(),
+                location.getAddress3(),
+                location.getAddress4(),
+                recommendation,
+                chart,
+                tags
+        );
+    }
+
+    private Fashion findFashionFor(float feelTmp, List<Fashion> fashions) {
+        return fashions.stream()
+                .filter(f -> f.getStartTemp() <= feelTmp && feelTmp <= f.getEndTemp())
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(FashionErrorCode.FASHION_NOT_FOUND));
+    }
+
+    private FashionDetailResponseDto.Clothing toClothing(Fashion fashion) {
+        return new FashionDetailResponseDto.Clothing(fashion.getName(), fashion.getImgUrl());
+    }
+
+    private FashionDetailResponseDto.Tag toTag(SeasonTag tag) {
+        return new FashionDetailResponseDto.Tag(tag.getId(), tag.getName());
+    }
+
+    private FashionDetailResponseDto.Tag toTag(WeatherTag tag) {
+        return new FashionDetailResponseDto.Tag(tag.getId(), tag.getName());
+    }
+
+    private FashionDetailResponseDto.Tag toTag(TemperatureTag tag) {
+        return new FashionDetailResponseDto.Tag(tag.getId(), tag.getName());
+    }
+
 }

--- a/src/main/java/com/weady/weady/domain/location/entity/Location.java
+++ b/src/main/java/com/weady/weady/domain/location/entity/Location.java
@@ -19,16 +19,19 @@ public class Location extends BaseEntity {
     private String bCode;
 
     @Column(length = 50)
-    private String name;
+    private String address1;
+    @Column(length = 50)
+    private String address2;
+    @Column(length = 50)
+    private String address3;
+    @Column(length = 50)
+    private String address4;
 
     private Integer nx;
     private Integer ny;
 
-    @Column(length = 20)
-    private String midTermLandRegId;
-
-    @Column(length = 20)
-    private String midTermTempRegId;
+    @Column(length = 50)
+    private String midTermRegCode;
 
 
     @OneToOne(mappedBy = "location")

--- a/src/main/java/com/weady/weady/domain/weather/entity/LocationWeatherSnapshot.java
+++ b/src/main/java/com/weady/weady/domain/weather/entity/LocationWeatherSnapshot.java
@@ -22,7 +22,9 @@ public class LocationWeatherSnapshot extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Location location;
 
-    private LocalDateTime observationTime;
+    private Integer observationDate;
+
+    private Integer observationTime;
 
     private Integer date; // 20250723
 

--- a/src/main/java/com/weady/weady/domain/weather/repository/DailySummaryRepository.java
+++ b/src/main/java/com/weady/weady/domain/weather/repository/DailySummaryRepository.java
@@ -1,0 +1,23 @@
+package com.weady.weady.domain.weather.repository;
+
+import com.weady.weady.domain.weather.entity.DailySummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DailySummaryRepository extends JpaRepository<DailySummary, Long> {
+    @Query("""
+        select ds
+        from DailySummary ds
+        join fetch ds.seasonTag st
+        join fetch ds.weatherTag wt
+        join fetch ds.temperatureTag tt
+        where ds.location.id = :locationId
+          and ds.reportDate = :reportDate
+    """)
+    Optional<DailySummary> findByLocationIdAndReportDateWithTags(@Param("locationId") Long locationId,
+                                                                 @Param("reportDate") LocalDate reportDate);
+}

--- a/src/main/java/com/weady/weady/domain/weather/repository/LocationWeatherSnapshotRepository.java
+++ b/src/main/java/com/weady/weady/domain/weather/repository/LocationWeatherSnapshotRepository.java
@@ -2,8 +2,12 @@ package com.weady.weady.domain.weather.repository;
 
 import com.weady.weady.domain.weather.entity.LocationWeatherSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface LocationWeatherSnapshotRepository extends JpaRepository<LocationWeatherSnapshot, Long> {
     Optional<LocationWeatherSnapshot> findByLocationIdAndDateAndTime(Long locationId, Integer date, Integer time);
+
+    List<LocationWeatherSnapshot> findByLocationIdAndDateOrderByTimeAsc(Long locationId, Integer date);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#29 

> ex) #이슈번호, #이슈번호

## 📝작업 내용
옷차림 화면에서 상세 정보를 조회하는 API 입니다.
사용자가 접속한 위치, 체감온도, 옷차림 그래프를 위한 매 시간의 정보, 접속한 시간의 요약 정보 그리고 그 위치의 날씨,계절,온도 태그를 response body로 보내줍니다.
(추가적으로, location_weather_snapshot 디비의 변경으로 엔티티를 수정하였습니다.)
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?