### PR TITLE
[FEAT] Board / 게시글 수정 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/weady/weady/domain/board/controller/BoardController.java
+++ b/src/main/java/com/weady/weady/domain/board/controller/BoardController.java
@@ -28,15 +28,31 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping(value = "/create") // , consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "게시물 작성 api", description = "로그인 한 사용자가 게시물을 작성하는 API입니다.")
+    @Operation(summary = "게시물 작성 API", description = "로그인 한 사용자가 게시물을 작성하는 API입니다.")
     public ResponseEntity<ApiResponse<BoardResponseDto>> createPost (
             //@RequestPart(value = "images", required = false) List<MultipartFile> images,
             @RequestBody BoardCreateRequestDto postData){
-        BoardResponseDto responseDto = boardService.createPost(postData);
 
+        BoardResponseDto responseDto = boardService.createPost(postData);
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 작성 성공!"));
     }
 
+    @PatchMapping(value = "/{boardId}")
+    @Operation(summary = "게시물 수정 API")
+    public ResponseEntity<ApiResponse<BoardResponseDto>> updatePost (
+            @PathVariable(name = "boardId") Long boardId,
+            @RequestBody BoardCreateRequestDto postData) {
+
+        BoardResponseDto responseDto = boardService.updatePost(postData, boardId);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 수정 성공!"));
+    }
+
+    @DeleteMapping(value = "/{boardId}")
+    @Operation(summary = "게시물 삭제 API")
+    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable(name = "boardId") Long boardId) {
+        boardService.deletePost(boardId);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of("게시물 삭제 성공!"));
+    }
 
     @GetMapping(value = "")
     @Operation(summary = "보드 홈 게시물 전체 조회 API", description = "전체 게시물을 조회하는 API입니다. 날씨, 계절 태그 ID로 게시글을 필터링 할 수 있습니다.")
@@ -54,17 +70,17 @@ public class BoardController {
 
 
     @GetMapping(value = "/{boardId}")
-    @Operation(summary = "게시물 조회 api", description = "특정 게시물을 조회하는 API입니다.")
+    @Operation(summary = "게시물 조회 API", description = "특정 게시물을 조회하는 API입니다.")
     @Parameters({
             @Parameter(name="boardId", description = "게시물의 아이디, path variable 입니다.")})
-    public ResponseEntity<ApiResponse<BoardResponseDto>> getPostById(@PathVariable(name = "boardId") Long storeId){
-        BoardResponseDto responseDto = boardService.getPostById(storeId);
+    public ResponseEntity<ApiResponse<BoardResponseDto>> getPostById(@PathVariable(name = "boardId") Long boardId){
+        BoardResponseDto responseDto = boardService.getPostById(boardId);
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 조회 성공!"));
     }
 
 
     @PostMapping(value = "/{boardId}/good")
-    @Operation(summary = "게시물 좋아요 api")
+    @Operation(summary = "게시물 좋아요 API")
     public ResponseEntity<ApiResponse<BoardGoodResponseDto>> addGood(@PathVariable(name = "boardId") Long boardId){
 
         BoardGoodResponseDto responseDto = boardService.addGood(boardId);
@@ -72,7 +88,7 @@ public class BoardController {
     }
 
     @DeleteMapping(value = "/{boardId}/good")
-    @Operation(summary = "게시물 좋아요 취소 api")
+    @Operation(summary = "게시물 좋아요 취소 API")
     public ResponseEntity<ApiResponse<BoardGoodResponseDto>> cancelGood(@PathVariable(name = "boardId") Long boardId){
 
         BoardGoodResponseDto responseDto = boardService.cancelGood(boardId);

--- a/src/main/java/com/weady/weady/domain/board/dto/response/BoardGoodResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/response/BoardGoodResponseDto.java
@@ -4,6 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record BoardGoodResponseDto(
-        Boolean liked,
+        Boolean goodStatus,
         Integer goodCount
 ){}

--- a/src/main/java/com/weady/weady/domain/board/dto/response/BoardResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/response/BoardResponseDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Builder
 public record BoardResponseDto(
         Long boardId,
+        Long userId,
         String userName,
         String userProfileImageUrl,
         Boolean isPublic,

--- a/src/main/java/com/weady/weady/domain/board/entity/board/Board.java
+++ b/src/main/java/com/weady/weady/domain/board/entity/board/Board.java
@@ -77,14 +77,37 @@ public class Board extends BaseEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardGood> boardGoodList = new ArrayList<>();
 
+    public void updateBoard(Boolean isPublic, String content, SeasonTag seasonTag,
+                            TemperatureTag temperatureTag, WeatherTag weatherTag) {
+        this.isPublic = isPublic;
+        this.content = content;
+        this.seasonTag = seasonTag;
+        this.temperatureTag = temperatureTag;
+        this.weatherTag = weatherTag;
+    }
+
 
     public void updateBoardPlaceList(List<BoardPlace> boardPlaceList){
         boardPlaceList.forEach(boardPlace -> {boardPlace.setBoard(this);});
-        this.boardPlaceList = boardPlaceList;
+
+        this.boardPlaceList.clear();
+        this.boardPlaceList.addAll(boardPlaceList);
     }
 
     public void updateBoardStyleList(List<BoardStyle> boardStyleList){
         boardStyleList.forEach(boardStyle -> {boardStyle.setBoard(this);});
-        this.boardStyleList = boardStyleList;
+
+        // 게시글 수정 시 orphanRemoval 오류 발생 방지
+        this.boardStyleList.clear();
+        this.boardStyleList.addAll(boardStyleList);
+
+    }
+
+    public void increaseGoodCount() {
+        this.goodCount = this.goodCount + 1;
+    }
+
+    public void decreaseGoodCount() {
+        this.goodCount = this.goodCount - 1;
     }
 }

--- a/src/main/java/com/weady/weady/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/weady/weady/domain/board/mapper/BoardMapper.java
@@ -56,7 +56,7 @@ public class BoardMapper {
     /// 응답 dto ///
 
     // 게시물 조회 dto
-    public static BoardResponseDto toBoardResponseDto(Board board, User user) {
+    public static BoardResponseDto toBoardResponseDto(Board board, User user, boolean goodStatus) {
         List<Long> styleIdList = board.getBoardStyleList().stream()
                 .map(style -> style.getClothesStyleCategory().getId())
                 .collect(Collectors.toList());
@@ -64,10 +64,12 @@ public class BoardMapper {
         return BoardResponseDto.builder()
                 .boardId(board.getId())
                 .isPublic(board.getIsPublic())
+                .goodStatus(goodStatus)
                 .content(board.getContent())
                 .weatherTagId(board.getWeatherTag().getId())
                 .temperatureTagId(board.getTemperatureTag().getId())
                 .seasonTagId(board.getSeasonTag().getId())
+                .userId(user.getId())
                 .userName(user.getName())
                 .userProfileImageUrl(user.getProfileImageUrl())
                 .goodCount(board.getGoodCount())
@@ -113,9 +115,9 @@ public class BoardMapper {
     }
 
 
-    public static BoardGoodResponseDto toBoardGoodResponseDto(Boolean liked, Integer goodCount) {
+    public static BoardGoodResponseDto toBoardGoodResponseDto(Boolean goodStatus, Integer goodCount) {
         return BoardGoodResponseDto.builder()
-                .liked(liked)
+                .goodStatus(goodStatus)
                 .goodCount(goodCount)
                 .build();
     }

--- a/src/main/java/com/weady/weady/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/weady/weady/domain/board/repository/BoardRepository.java
@@ -4,7 +4,6 @@ import com.weady.weady.domain.board.entity.board.Board;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,14 +22,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             @Param("temperatureTagId") Long temperatureTagId,
             @Param("seasonTagId") Long seasonTagId,
             Pageable pageable);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Board b SET b.goodCount = b.goodCount + 1 WHERE b.id = :id")
-    void increaseGoodCount(@Param("id") Long boardId);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Board b SET b.goodCount = b.goodCount - 1 WHERE b.id = :id")
-    void decreaseGoodCount(@Param("id") Long boardId);
 
 }
 

--- a/src/main/java/com/weady/weady/domain/board/service/BoardService.java
+++ b/src/main/java/com/weady/weady/domain/board/service/BoardService.java
@@ -78,9 +78,72 @@ public class BoardService {
 
         boardRepository.save(board);
 
-        return BoardMapper.toBoardResponseDto(board, user);
+        return BoardMapper.toBoardResponseDto(board, user, false);
 
     }
+
+    /**
+     * 게시글 수정
+     * @return BoardResponseDto
+     * @thorws
+     */
+    @Transactional
+    public BoardResponseDto updatePost(BoardCreateRequestDto requestDto, Long boardId) {
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(()-> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
+
+        User boardUser = board.getUser(); // 작성자
+
+        Long userId = SecurityUtil.getCurrentUserId(); // 현재 로그인 한 사용자
+
+        if (!userId.equals(boardUser.getId())){
+            throw new BusinessException(BoardErrorCode.UNAUTHORIZED_UPDATE);
+        }
+
+        //날씨 태그 조회
+        SeasonTag seasonTag = seasonRepository.findById(requestDto.seasonTagId())
+                .orElseThrow(()-> new BusinessException(TagsErrorCode.SEASON_TAG_NOT_FOUND));
+
+        TemperatureTag temperatureTag = temperatureRepository.findById(requestDto.temperatureTagId())
+                .orElseThrow(()-> new BusinessException(TagsErrorCode.TEMPERATURE_TAG_NOT_FOUND));
+
+        WeatherTag weatherTag = weatherRepository.findById(requestDto.weatherTagId())
+                .orElseThrow(() -> new BusinessException(TagsErrorCode.WEATHER_TAG_NOT_FOUND));
+
+        List<ClothesStyleCategory> categories = styleCategoryRepository.findAllById(requestDto.styleIds());
+
+        // 변경 사항 업데이트
+        board.updateBoard(requestDto.isPublic(), requestDto.content(), seasonTag, temperatureTag, weatherTag);
+        board.updateBoardPlaceList(BoardMapper.toBoardPlaceList(requestDto.boardPlaceRequestDtoList()));
+        board.updateBoardStyleList(BoardMapper.toBoardStyleList(categories));
+
+        boolean goodStatus = boardGoodRepository.existsByBoardAndUser(board, boardUser);
+
+        return BoardMapper.toBoardResponseDto(board, boardUser, goodStatus);
+
+    }
+
+    /**
+     * 게시글 삭제
+     * @return
+     * @thorws
+     */
+    @Transactional
+    public void deletePost(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(()-> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
+
+        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
+                .orElseThrow(()-> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (board.getUser().equals(user)) {
+            boardRepository.delete(board);
+            return;
+        }
+        throw new BusinessException(BoardErrorCode.UNAUTHORIZED_DELETE);
+    }
+
 
     /**
      * 보드 홈 - 전체 게시글 조회
@@ -110,7 +173,9 @@ public class BoardService {
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
 
-        return BoardMapper.toBoardResponseDto(board, user);
+        boolean goodStatus = boardGoodRepository.existsByBoardAndUser(board, user);
+
+        return BoardMapper.toBoardResponseDto(board, user, goodStatus);
     }
 
     /**
@@ -118,6 +183,7 @@ public class BoardService {
      * @return BoardGoodResponseDto
      * @thorws
      */
+    @Transactional
     public BoardGoodResponseDto addGood(Long boardId) {
 
         // 좋아요 누르는 유저 정보
@@ -134,12 +200,8 @@ public class BoardService {
         BoardGood boardGood = BoardMapper.toBoardGood(board, user);
         boardGoodRepository.save(boardGood);
 
-        boardRepository.increaseGoodCount(boardId);
-        Board updatedBoard = boardRepository.findById(boardId)
-                .orElseThrow(() -> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
-
-
-        Integer goodCount = updatedBoard.getGoodCount();
+        board.increaseGoodCount();
+        Integer goodCount = board.getGoodCount();
 
         return BoardMapper.toBoardGoodResponseDto(true, goodCount);
 
@@ -163,11 +225,9 @@ public class BoardService {
 
         boardGoodRepository.deleteByBoardAndUser(board, user);
 
-        boardRepository.decreaseGoodCount(boardId);
-        Board updatedBoard = boardRepository.findById(boardId)
-                .orElseThrow(() -> new BusinessException(BoardErrorCode.BOARD_GOOD_NOT_FOUND));
+        board.decreaseGoodCount();
 
-        Integer goodCount = updatedBoard.getGoodCount();
+        Integer goodCount = board.getGoodCount();
 
         return BoardMapper.toBoardGoodResponseDto(false, goodCount);
 

--- a/src/main/java/com/weady/weady/global/common/error/errorCode/BoardErrorCode.java
+++ b/src/main/java/com/weady/weady/global/common/error/errorCode/BoardErrorCode.java
@@ -10,7 +10,9 @@ public enum BoardErrorCode implements ErrorCode {
 
     BOARD_NOT_FOUND(404, "해당 게시글을 찾을 수 없습니다."),
     BOARD_GOOD_NOT_FOUND(404, "좋아요 기록을 찾을 수 없습니다."),
-    ALREADY_LIKED(409, "이미 좋아요 한 게시물입니다.")
+    ALREADY_LIKED(409, "이미 좋아요 한 게시물입니다."),
+    UNAUTHORIZED_UPDATE(403, "게시물 수정 권한이 없습니다."),
+    UNAUTHORIZED_DELETE(403, "게시물 삭제 권한이 없습니다.")
     ;
 
     private final int code;


### PR DESCRIPTION
## #️⃣연관된 이슈

#53 

## 📝작업 내용

게시물을 수정하고 삭제하는 api를 구현했습니다. 현재 로그인 한 사용자가 게시물을 작성한 사용자일 때만 해당 작업을 수행할 수 있게 했습니다. 
추가로 기존에 작업했던 게시물 좋아요 기능을 일부 수정했습니다.  JPQL 쿼리로 DB에 접근 후 다시 보드를 조회해 영속성 컨텍스트에 변경사항을 반영하는 방식에서, 엔티티 내부에 좋아요 수 증가/감소 메서드를 만들어 더티 체킹 기반으로 관리하도록 수정했습니다!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
