### PR TITLE
[FEAT] Board / 게시물 신고 기능 및 댓글 API 구현

### DIFF
--- a/src/main/java/com/weady/weady/common/error/errorCode/BoardErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/BoardErrorCode.java
@@ -8,15 +8,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum BoardErrorCode implements ErrorCode {
 
+    //보드 관련
     BOARD_NOT_FOUND(404, "해당 게시글을 찾을 수 없습니다."),
     BOARD_GOOD_NOT_FOUND(404, "좋아요 기록을 찾을 수 없습니다."),
     ALREADY_LIKED(409, "이미 좋아요 한 게시물입니다."),
     UNAUTHORIZED_UPDATE(403, "게시물 수정 권한이 없습니다."),
-    UNAUTHORIZED_DELETE(403, "게시물 삭제 권한이 없습니다."),
+    UNAUTHORIZED_DELETE(403, "삭제 권한이 없습니다."),
     WEADYCHIVE_BOARD_NOT_FOUND(404, "스크랩 기록을 찾을 수 없습니다."),
     ALREADY_SCRAPED(409, "이미 스크랩 한 게시물입니다."),
     BOARD_HIDDEN_NOT_FOUND(404, "숨김 기록을 찾을 수 없습니다."),
-    ALREADY_HIDDEN(409, "이미 숨김 처리된 게시물입니다.")
+    ALREADY_HIDDEN(409, "이미 숨김 처리된 게시물입니다."),
+    ALREADY_REPORTED(409, "이미 신고 처리된 게시물입니다."),
+
+
+    //댓글 관련
+    COMMENT_NOT_FOUND(404, "해당 댓글을 찾을 수 없습니다."),
+
     ;
 
     private final int code;

--- a/src/main/java/com/weady/weady/domain/board/controller/BoardController.java
+++ b/src/main/java/com/weady/weady/domain/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.weady.weady.domain.board.controller;
 
 import com.weady.weady.domain.board.dto.request.BoardCreateRequestDto;
+import com.weady.weady.domain.board.dto.request.ReportRequestDto;
 import com.weady.weady.domain.board.dto.response.BoardGoodResponseDto;
 import com.weady.weady.domain.board.dto.response.BoardHomeResponseDto;
 import com.weady.weady.domain.board.dto.response.BoardResponseDto;
@@ -27,35 +28,9 @@ public class BoardController {
 
     private final BoardService boardService;
 
-    @PostMapping(value = "/create") // , consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "게시물 작성 API", description = "로그인 한 사용자가 게시물을 작성하는 API입니다.")
-    public ResponseEntity<ApiResponse<BoardResponseDto>> createPost(
-            //@RequestPart(value = "images", required = false) List<MultipartFile> images,
-            @RequestBody BoardCreateRequestDto postData) {
-
-        BoardResponseDto responseDto = boardService.createPost(postData);
-        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 작성 성공!"));
-    }
-
-    @PatchMapping(value = "/{boardId}")
-    @Operation(summary = "게시물 수정 API")
-    public ResponseEntity<ApiResponse<BoardResponseDto>> updatePost(
-            @PathVariable(name = "boardId") Long boardId,
-            @RequestBody BoardCreateRequestDto postData) {
-
-        BoardResponseDto responseDto = boardService.updatePost(postData, boardId);
-        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 수정 성공!"));
-    }
-
-    @DeleteMapping(value = "/{boardId}")
-    @Operation(summary = "게시물 삭제 API")
-    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable(name = "boardId") Long boardId) {
-        boardService.deletePost(boardId);
-        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of("게시물 삭제 성공!"));
-    }
 
     @GetMapping(value = "")
-    @Operation(summary = "보드 홈 게시물 전체 조회 API", description = "전체 게시물을 조회하는 API입니다. 날씨, 계절 태그 ID로 게시글을 필터링 할 수 있습니다.")
+    @Operation(summary = "1. 보드 홈 게시물 전체 조회 API", description = "전체 게시물을 조회하는 API입니다. 날씨, 계절 태그 ID로 게시글을 필터링 할 수 있습니다.")
     public ResponseEntity<ApiResponse<Slice<BoardHomeResponseDto>>> getFilteredAndSortedBoards(
             @RequestParam(name = "seasonTagId", required = false) Long seasonTagId,
             @RequestParam(name = "weatherTagId", required = false) Long weatherTagId,
@@ -69,7 +44,7 @@ public class BoardController {
 
 
     @GetMapping(value = "/{boardId}")
-    @Operation(summary = "게시물 조회 API", description = "특정 게시물을 조회하는 API입니다.")
+    @Operation(summary = "2. 게시물 조회 API", description = "특정 게시물을 조회하는 API입니다.")
     @Parameters({
             @Parameter(name = "boardId", description = "게시물의 아이디, path variable 입니다.")})
     public ResponseEntity<ApiResponse<BoardResponseDto>> getPostById(@PathVariable(name = "boardId") Long boardId) {
@@ -78,8 +53,38 @@ public class BoardController {
     }
 
 
+    @PostMapping(value = "/create") // , consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "3. 게시물 작성 API", description = "로그인 한 사용자가 게시물을 작성하는 API입니다.")
+    public ResponseEntity<ApiResponse<BoardResponseDto>> createPost(
+            //@RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @RequestBody BoardCreateRequestDto postData) {
+
+        BoardResponseDto responseDto = boardService.createPost(postData);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 작성 성공!"));
+    }
+
+
+    @PatchMapping(value = "/{boardId}")
+    @Operation(summary = "4. 게시물 수정 API")
+    public ResponseEntity<ApiResponse<BoardResponseDto>> updatePost(
+            @PathVariable(name = "boardId") Long boardId,
+            @RequestBody BoardCreateRequestDto postData) {
+
+        BoardResponseDto responseDto = boardService.updatePost(postData, boardId);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 수정 성공!"));
+    }
+
+
+    @DeleteMapping(value = "/{boardId}")
+    @Operation(summary = "5. 게시물 삭제 API")
+    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable(name = "boardId") Long boardId) {
+        boardService.deletePost(boardId);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of("게시물 삭제 성공!"));
+    }
+
+
     @PostMapping(value = "/{boardId}/good")
-    @Operation(summary = "게시물 좋아요 API")
+    @Operation(summary = "8. 게시물 좋아요 API")
     public ResponseEntity<ApiResponse<BoardGoodResponseDto>> addGood(@PathVariable(name = "boardId") Long boardId) {
 
         BoardGoodResponseDto responseDto = boardService.addGood(boardId);
@@ -87,24 +92,35 @@ public class BoardController {
     }
 
     @DeleteMapping(value = "/{boardId}/good")
-    @Operation(summary = "게시물 좋아요 취소 API")
+    @Operation(summary = "9. 게시물 좋아요 취소 API")
     public ResponseEntity<ApiResponse<BoardGoodResponseDto>> cancelGood(@PathVariable(name = "boardId") Long boardId) {
 
         BoardGoodResponseDto responseDto = boardService.cancelGood(boardId);
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto, "게시글 좋아요 취소 성공!"));
     }
 
+
+    @PostMapping(value = "/{boardId}/report")
+    @Operation(summary = "10. 게시물 신고 API")
+    public ResponseEntity<ApiResponse<Void>> reportPost(
+            @PathVariable(name = "boardId") Long boardId,
+            @RequestBody ReportRequestDto requestDto) {
+        boardService.reportPost(boardId, requestDto);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of("게시물 신고 성공!"));
+    }
+
+
     @PostMapping(value = "/{boardId}/hide")
-    @Operation(summary = "게시물 숨김 API")
+    @Operation(summary = "11. 게시물 숨김 API")
     public ResponseEntity<ApiResponse<Void>> hidePost(@PathVariable(name = "boardId") Long boardId) {
-        boardService.hideBoard(boardId);
+        boardService.hidePost(boardId);
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of("게시물 숨김 성공!"));
     }
 
     @DeleteMapping(value = "/{boardId}/hide")
-    @Operation(summary = "게시물 숨김 취소 API")
+    @Operation(summary = "12. 게시물 숨김 취소 API")
     public ResponseEntity<ApiResponse<Void>> unhidePost(@PathVariable(name = "boardId") Long boardId) {
-        boardService.unhideBoard(boardId);
+        boardService.unhidePost(boardId);
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of("게시물 숨김 취소 성공!"));
     }
 }

--- a/src/main/java/com/weady/weady/domain/board/controller/CommentController.java
+++ b/src/main/java/com/weady/weady/domain/board/controller/CommentController.java
@@ -1,0 +1,52 @@
+package com.weady.weady.domain.board.controller;
+
+
+import com.weady.weady.common.apiResponse.ApiResponse;
+import com.weady.weady.common.apiResponse.ApiSuccessResponse;
+import com.weady.weady.common.util.ResponseEntityUtil;
+import com.weady.weady.domain.board.dto.request.CommentCreateRequestDto;
+import com.weady.weady.domain.board.dto.response.CommentResponseDto;
+import com.weady.weady.domain.board.dto.response.CommentWithChildResponseDto;
+import com.weady.weady.domain.board.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Comment", description = "웨디보드 댓글 관련 API")
+@RequestMapping("/api/v1")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping(value = "/board/{boardId}/comments")
+    @Operation(summary = "1. 댓글 전체 조회 API")
+    public ResponseEntity<ApiResponse<Slice<CommentWithChildResponseDto>>> getComments(
+            @PathVariable(name = "boardId") Long boardId,
+            @RequestParam(name = "size", required = false, defaultValue = "10") Integer size
+    ) {
+        Slice<CommentWithChildResponseDto> responseDtoList = commentService.getComments(boardId, size);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDtoList, "댓글 조회 성공!"));
+    }
+
+
+    @PostMapping(value = "/board/{boardId}/comments")
+    @Operation(summary = "2. 댓글 작성 API", description = "댓글 및 대댓글을 작성하는 API입니다.")
+    public ResponseEntity<ApiResponse<CommentResponseDto>> createComment(
+            @PathVariable(name = "boardId") Long boardId,
+            @RequestBody CommentCreateRequestDto requestDto) {
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(commentService.createComment(requestDto, boardId), "댓글 작성 성공!"));
+    }
+
+    @DeleteMapping(value = "/board/comments/{commentId}")
+    @Operation(summary = "3. 댓글 삭제 API")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable(name = "commentId") Long commentId) {
+        commentService.deleteComment(commentId);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of("댓글 삭제 성공!"));
+    }
+
+}

--- a/src/main/java/com/weady/weady/domain/board/dto/request/CommentCreateRequestDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/request/CommentCreateRequestDto.java
@@ -1,0 +1,11 @@
+package com.weady.weady.domain.board.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record CommentCreateRequestDto(
+        Long parentId,
+        @NotBlank(message = "최소 한 글자 이상을 입력해야 합니다.")
+        String content
+) {}

--- a/src/main/java/com/weady/weady/domain/board/dto/request/ReportRequestDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/request/ReportRequestDto.java
@@ -1,0 +1,8 @@
+package com.weady.weady.domain.board.dto.request;
+
+import com.weady.weady.domain.board.entity.board.ReportType;
+
+public record ReportRequestDto(
+        ReportType reportType,
+        String content
+){}

--- a/src/main/java/com/weady/weady/domain/board/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/response/CommentResponseDto.java
@@ -1,0 +1,15 @@
+package com.weady.weady.domain.board.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CommentResponseDto(
+        Long commentId,
+        Long parentId,
+        String username,
+        String profileImageUrl,
+        String content,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/weady/weady/domain/board/dto/response/CommentWithChildResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/response/CommentWithChildResponseDto.java
@@ -1,0 +1,18 @@
+package com.weady.weady.domain.board.dto.response;
+
+import com.weady.weady.domain.board.entity.comment.BoardComment;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record CommentWithChildResponseDto(
+        Long commentId,
+        Long parentId,
+        String username,
+        String profileImageUrl,
+        String content,
+        List<CommentResponseDto> childCommentsList,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/weady/weady/domain/board/entity/board/Report.java
+++ b/src/main/java/com/weady/weady/domain/board/entity/board/Report.java
@@ -4,6 +4,7 @@ import com.weady.weady.domain.user.entity.User;
 import com.weady.weady.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @AllArgsConstructor
@@ -23,6 +24,7 @@ public class Report extends BaseEntity {
     private String content;
 
     @Enumerated(EnumType.STRING)
+    @ColumnDefault("'PENDING'")
     private Status status;
 
     @ManyToOne

--- a/src/main/java/com/weady/weady/domain/board/entity/comment/BoardComment.java
+++ b/src/main/java/com/weady/weady/domain/board/entity/comment/BoardComment.java
@@ -30,7 +30,6 @@ public class BoardComment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn
-    private BoardComment boardComment;
-
+    private BoardComment parentComment;
 
 }

--- a/src/main/java/com/weady/weady/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/weady/weady/domain/board/mapper/BoardMapper.java
@@ -59,6 +59,18 @@ public class BoardMapper {
                 .build();
     }
 
+    //content null일 수도 있는데,,,
+    public static Report toReport(Board board, User user, ReportType reportType, String content) {
+        return Report.builder()
+                .board(board)
+                .user(user)
+                .reportType(reportType)
+                .content(content)
+                .build();
+    }
+
+
+
 
     /// 응답 dto ///
 

--- a/src/main/java/com/weady/weady/domain/board/mapper/CommentMapper.java
+++ b/src/main/java/com/weady/weady/domain/board/mapper/CommentMapper.java
@@ -1,0 +1,65 @@
+package com.weady.weady.domain.board.mapper;
+
+import com.weady.weady.domain.board.dto.response.CommentResponseDto;
+import com.weady.weady.domain.board.dto.response.CommentWithChildResponseDto;
+import com.weady.weady.domain.board.entity.board.Board;
+import com.weady.weady.domain.board.entity.comment.BoardComment;
+import com.weady.weady.domain.user.entity.User;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CommentMapper {
+
+    public static BoardComment toBoardComment(BoardComment boardComment, User user, Board board, String content) {
+
+        return BoardComment.builder()
+                .parentComment(boardComment)
+                .board(board)
+                .user(user)
+                .content(content)
+                .build();
+    }
+
+
+    public static CommentResponseDto toCommentResponseDto(BoardComment boardComment) {
+
+        Long parentId = null;
+        if(boardComment.getParentComment() != null) {
+            parentId = boardComment.getParentComment().getId();
+        }
+
+        return CommentResponseDto.builder()
+                .commentId(boardComment.getId())
+                .parentId(parentId)
+                .username(boardComment.getUser().getName())
+                .profileImageUrl(boardComment.getUser().getProfileImageUrl())
+                .content(boardComment.getContent())
+                .createdAt(boardComment.getCreatedAt())
+                .build();
+    }
+
+
+    public static CommentWithChildResponseDto toCommentWithChildResponseDto(BoardComment boardComment, List<BoardComment> childComments) {
+
+        Long parentId = null;
+        if(boardComment.getParentComment() != null) {
+            parentId = boardComment.getParentComment().getId();
+        }
+
+        return CommentWithChildResponseDto.builder()
+                .commentId(boardComment.getId())
+                .parentId(parentId)
+                .username(boardComment.getUser().getName())
+                .profileImageUrl(boardComment.getUser().getProfileImageUrl())
+                .content(boardComment.getContent())
+                .childCommentsList(childComments.stream()
+                        .map(CommentMapper::toCommentResponseDto)
+                        .collect(Collectors.toList()))
+                .createdAt(boardComment.getCreatedAt())
+
+                .build();
+    }
+
+}

--- a/src/main/java/com/weady/weady/domain/board/repository/CommentRepository.java
+++ b/src/main/java/com/weady/weady/domain/board/repository/CommentRepository.java
@@ -1,0 +1,21 @@
+package com.weady.weady.domain.board.repository;
+
+import com.weady.weady.domain.board.entity.board.Board;
+import com.weady.weady.domain.board.entity.comment.BoardComment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<BoardComment, Long> {
+    // 부모 댓글만 페이징 조회
+    Slice<BoardComment> findByBoardAndParentCommentIsNull(Board board, Pageable pageable);
+
+    // 자식 댓글은 부모 ID 기준. 작성된 순서로 정렬된 리스트로 조회
+    List<BoardComment> findAllByParentCommentId(Long parentId);
+
+
+    void deleteAllByParentComment(BoardComment parentComment);
+
+}

--- a/src/main/java/com/weady/weady/domain/board/repository/ReportRepository.java
+++ b/src/main/java/com/weady/weady/domain/board/repository/ReportRepository.java
@@ -1,0 +1,12 @@
+package com.weady.weady.domain.board.repository;
+
+import com.weady.weady.domain.board.entity.board.Board;
+import com.weady.weady.domain.board.entity.board.Report;
+import com.weady.weady.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    boolean existsByBoardAndUser(Board board, User user);
+
+
+}

--- a/src/main/java/com/weady/weady/domain/board/service/CommentService.java
+++ b/src/main/java/com/weady/weady/domain/board/service/CommentService.java
@@ -1,0 +1,127 @@
+package com.weady.weady.domain.board.service;
+
+
+import com.weady.weady.common.error.errorCode.BoardErrorCode;
+import com.weady.weady.common.error.errorCode.UserErrorCode;
+import com.weady.weady.common.error.exception.BusinessException;
+import com.weady.weady.common.util.SecurityUtil;
+import com.weady.weady.domain.board.dto.request.CommentCreateRequestDto;
+import com.weady.weady.domain.board.dto.response.CommentResponseDto;
+import com.weady.weady.domain.board.dto.response.CommentWithChildResponseDto;
+import com.weady.weady.domain.board.entity.board.Board;
+import com.weady.weady.domain.board.entity.comment.BoardComment;
+import com.weady.weady.domain.board.mapper.CommentMapper;
+import com.weady.weady.domain.board.repository.BoardRepository;
+import com.weady.weady.domain.board.repository.CommentRepository;
+import com.weady.weady.domain.user.entity.User;
+import com.weady.weady.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+
+
+    /**
+     * 1. 전체 댓글 조회
+     * @return Slice<CommentWithChildResponseDto>
+     * @thorws
+     */
+    @Transactional(readOnly = true)
+    public Slice<CommentWithChildResponseDto> getComments(Long boardId, Integer size) {
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(0, size);
+        Slice<BoardComment> parentComments = commentRepository.findByBoardAndParentCommentIsNull(board, pageable);
+
+        // 부모 댓글과 자식 댓글을 매핑
+        List<CommentWithChildResponseDto> commentResponses = parentComments.stream()
+                .map(parentComment -> {
+                    List<BoardComment> childComments = commentRepository.findAllByParentCommentId(parentComment.getId());
+                    return CommentMapper.toCommentWithChildResponseDto(parentComment, childComments);
+                })
+                .collect(Collectors.toList());
+        return new SliceImpl<>(commentResponses);
+    }
+
+    /**
+     * 2. 댓글 및 대댓글 작성
+     * @return CommentResponseDto
+     * @thorws
+     */
+    @Transactional
+    public CommentResponseDto createComment(CommentCreateRequestDto requestDto, Long boardId) {
+
+        // 댓글 작성자 정보 조회
+        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
+
+        BoardComment parentComment = null;
+
+        if(requestDto.parentId() != null) {
+            parentComment = commentRepository.findById(requestDto.parentId())
+                    .orElseThrow(() -> new BusinessException(BoardErrorCode.COMMENT_NOT_FOUND));
+
+            // 대댓글의 대댓글일 경우 -> 최상위 부모 댓글의 자식 댓글로 지정
+            if (parentComment.getParentComment() != null) {
+                parentComment = parentComment.getParentComment();
+            }
+        }
+
+        BoardComment newBoardComment = CommentMapper.toBoardComment(parentComment, user, board, requestDto.content());
+
+        // 데이터 저장
+        commentRepository.save(newBoardComment);
+
+        return CommentMapper.toCommentResponseDto(newBoardComment);
+
+    }
+
+
+    /**
+     * 4. 댓글 삭제
+     * @return
+     * @thorws
+     */
+    @Transactional
+    public void deleteComment(Long commentId) {
+
+        BoardComment boardComment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(BoardErrorCode.COMMENT_NOT_FOUND));
+
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+        Long commentAuthorId = boardComment.getUser().getId();
+        Long postAuthorId = boardComment.getBoard().getUser().getId();
+
+        if (Objects.equals(commentAuthorId, currentUserId) || Objects.equals(postAuthorId, currentUserId)) {
+            //자식 댓글 먼저 삭제 후 부모 댓글 삭제
+            commentRepository.deleteAllByParentComment(boardComment);
+            commentRepository.delete(boardComment);
+            return;
+        }
+        throw new BusinessException(BoardErrorCode.UNAUTHORIZED_DELETE);
+    }
+
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#71 
## 📝작업 내용

대댓글의 최대 깊이를 1로 제한하기 위해, 자식 댓글에 다시 답글을 달려고 하는 경우에는 해당 자식 댓글의 부모 댓글을 부모로 설정하는 로직을 구현했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
