### PR TITLE
[FEAT] MyPage / 마이페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/weady/weady/domain/board/repository/BoardImgRepository.java
+++ b/src/main/java/com/weady/weady/domain/board/repository/BoardImgRepository.java
@@ -1,0 +1,18 @@
+package com.weady.weady.domain.board.repository;
+
+import com.weady.weady.domain.board.entity.board.BoardImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface BoardImgRepository extends JpaRepository<BoardImg, Long> {
+    @Query("""
+        SELECT i.imgUrl
+        FROM BoardImg i
+        WHERE i.board.id = :boardId
+          AND i.imgOrder = 1
+    """)
+    Optional<String> findThumbnailUrlByBoardId(@Param("boardId") Long boardId);
+}

--- a/src/main/java/com/weady/weady/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/weady/weady/domain/board/repository/BoardRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
@@ -27,6 +29,20 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             @Param("userId") Long userId,
             Pageable pageable);
 
+
+    @Query("""
+        SELECT b
+        FROM Board b
+        WHERE b.user.id = :userId
+          AND FUNCTION('YEAR', b.createdAt) = :year
+          AND FUNCTION('MONTH', b.createdAt) = :month
+        ORDER BY b.createdAt ASC
+    """)
+    List<Board> findBoardsByUserIdAndYearMonth(@Param("userId") Long userId,
+                                               @Param("year") int year,
+                                               @Param("month") int month);
+
 }
+
 
 

--- a/src/main/java/com/weady/weady/domain/user/controller/UserController.java
+++ b/src/main/java/com/weady/weady/domain/user/controller/UserController.java
@@ -3,9 +3,11 @@ package com.weady.weady.domain.user.controller;
 import com.weady.weady.domain.user.dto.request.OnboardRequest;
 import com.weady.weady.domain.user.dto.request.UpdateNowLocationRequest;
 import com.weady.weady.domain.user.dto.request.UpdateUserProfileRequest;
+import com.weady.weady.domain.user.dto.response.GetMyPageResponse;
 import com.weady.weady.domain.user.dto.response.OnboardResponse;
 import com.weady.weady.domain.user.dto.response.UpdateNowLocationResponse;
 import com.weady.weady.domain.user.dto.response.UpdateUserProfileResponse;
+import com.weady.weady.domain.user.service.MyPageService;
 import com.weady.weady.domain.user.service.UserService;
 import com.weady.weady.common.apiResponse.ApiResponse;
 import com.weady.weady.common.apiResponse.ApiSuccessResponse;
@@ -13,6 +15,7 @@ import com.weady.weady.common.util.ResponseEntityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,6 +23,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/users")
 public class UserController {
     private final UserService userService;
+    private final MyPageService myPageService;
+
     @PostMapping("/onboarding")
     public ResponseEntity<ApiResponse<OnboardResponse>> onboard(@RequestBody @Valid OnboardRequest request) {
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(userService.onboard(request)));
@@ -33,5 +38,14 @@ public class UserController {
     @PatchMapping("/profile")
     public ResponseEntity<ApiResponse<UpdateUserProfileResponse>> updateUserProfile(@RequestBody @Valid UpdateUserProfileRequest request){
         return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(userService.updateUserProfile(request)));
+    }
+
+    @GetMapping("/my-page")
+    public ResponseEntity<ApiResponse<GetMyPageResponse>> getMyPage(
+            @RequestParam int year,
+            @RequestParam int month) {
+        GetMyPageResponse response = myPageService.getMyPage(year, month);
+
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(response));
     }
 }

--- a/src/main/java/com/weady/weady/domain/user/dto/response/GetMyPageResponse.java
+++ b/src/main/java/com/weady/weady/domain/user/dto/response/GetMyPageResponse.java
@@ -1,0 +1,18 @@
+package com.weady.weady.domain.user.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record GetMyPageResponse(Long userId,
+                                String name,
+                                String profileImageUrl,
+                                List<CalendarResponse> calendar) {
+
+    @Builder
+    public record CalendarResponse(LocalDate date,
+                                   String thumbnailUrl
+    ) {}
+}

--- a/src/main/java/com/weady/weady/domain/user/mapper/MyPageMapper.java
+++ b/src/main/java/com/weady/weady/domain/user/mapper/MyPageMapper.java
@@ -1,0 +1,26 @@
+package com.weady.weady.domain.user.mapper;
+
+import com.weady.weady.domain.user.dto.response.GetMyPageResponse;
+import com.weady.weady.domain.user.entity.User;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class MyPageMapper {
+
+    public static GetMyPageResponse toGetMyPageResponse(User user, List<GetMyPageResponse.CalendarResponse> calendar) {
+        return GetMyPageResponse.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .profileImageUrl(user.getProfileImageUrl())
+                .calendar(calendar)
+                .build();
+    }
+
+    public static GetMyPageResponse.CalendarResponse toCalendarResponse(LocalDate date, String thumbnailUrl) {
+        return GetMyPageResponse.CalendarResponse.builder()
+                .date(date)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/weady/weady/domain/user/service/MyPageService.java
+++ b/src/main/java/com/weady/weady/domain/user/service/MyPageService.java
@@ -1,0 +1,61 @@
+package com.weady.weady.domain.user.service;
+
+import com.weady.weady.common.error.errorCode.UserErrorCode;
+import com.weady.weady.common.error.exception.BusinessException;
+import com.weady.weady.common.util.SecurityUtil;
+import com.weady.weady.domain.board.entity.board.Board;
+import com.weady.weady.domain.board.repository.BoardImgRepository;
+import com.weady.weady.domain.board.repository.BoardRepository;
+import com.weady.weady.domain.user.dto.response.GetMyPageResponse;
+import com.weady.weady.domain.user.entity.User;
+import com.weady.weady.domain.user.mapper.MyPageMapper;
+import com.weady.weady.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final BoardImgRepository boardImgRepository;
+
+    @Transactional(readOnly = true)
+    public GetMyPageResponse getMyPage(int year, int month) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        List<Board> boards = boardRepository.findBoardsByUserIdAndYearMonth(userId, year, month);
+
+        Map<LocalDate, Board> firstBoardByDate = boards.stream()
+                .collect(Collectors.groupingBy(
+                        b -> b.getCreatedAt().toLocalDate(),
+                        Collectors.collectingAndThen(
+                                Collectors.maxBy(Comparator.comparing(Board::getCreatedAt)),
+                                Optional::get
+                        )
+                ));
+
+        List<GetMyPageResponse.CalendarResponse> calendar = firstBoardByDate.entrySet().stream()
+                .map(entry -> {
+                    Long boardId = entry.getValue().getId();
+                    String thumbnail = boardImgRepository
+                            .findThumbnailUrlByBoardId(boardId)
+                            .orElse(null);
+                    return MyPageMapper.toCalendarResponse(entry.getKey(), thumbnail);
+                })
+                .toList();
+
+        return MyPageMapper.toGetMyPageResponse(user, calendar);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#74 

> ex) #이슈번호, #이슈번호

## 📝작업 내용
마이페이지에서 닉네임과 프로필 이미지, 캘린더를 조회합니다.
썸네일 이미지는 가장 최근에 올린 글의 첫번째 사진으로 특정했습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?