### PR TITLE
[FEAT] Board / 옷 정보 태그 기능 추가 및 현재 위치 기준 날씨 정보 저장 API 구현

### DIFF
--- a/src/main/java/com/weady/weady/common/config/SwaggerConfig.java
+++ b/src/main/java/com/weady/weady/common/config/SwaggerConfig.java
@@ -28,7 +28,7 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(apiInfo())
                 .addSecurityItem(securityRequirement)
-                .components(components);
+                .components(components)
                 .addServersItem(new Server().url("https://weadyapi.pro"));  // ✅ 이거 추가!
     }
 

--- a/src/main/java/com/weady/weady/common/config/SwaggerConfig.java
+++ b/src/main/java/com/weady/weady/common/config/SwaggerConfig.java
@@ -28,7 +28,7 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(apiInfo())
                 .addSecurityItem(securityRequirement)
-                .components(components)
+                .components(components);
                 .addServersItem(new Server().url("https://weadyapi.pro"));  // ✅ 이거 추가!
     }
 

--- a/src/main/java/com/weady/weady/domain/board/dto/request/BoardBrandRequestDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/request/BoardBrandRequestDto.java
@@ -1,0 +1,9 @@
+package com.weady.weady.domain.board.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record BoardBrandRequestDto(
+        String brand,
+        String product
+) {}

--- a/src/main/java/com/weady/weady/domain/board/dto/request/BoardCreateRequestDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/request/BoardCreateRequestDto.java
@@ -9,14 +9,12 @@ public record BoardCreateRequestDto ( // 이미지 파일 제외 postData 에 �
                                       Boolean isPublic,
                                       String content,
 
+                                      Long seasonTagId,
                                       Long weatherTagId,
                                       Long temperatureTagId,
-                                      Long seasonTagId,
 
                                       List<BoardPlaceRequestDto> boardPlaceRequestDtoList,
-                                      List<Long> styleIds
-                                      //List<Long> brandId
-
-) {
-}
+                                      List<Long> styleIds,
+                                      List<BoardBrandRequestDto> boardBrandRequestDtoList
+) {}
 

--- a/src/main/java/com/weady/weady/domain/board/dto/response/BoardBrandResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/response/BoardBrandResponseDto.java
@@ -1,0 +1,9 @@
+package com.weady.weady.domain.board.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BoardBrandResponseDto(
+        String brand,
+        String product
+) {}

--- a/src/main/java/com/weady/weady/domain/board/dto/response/BoardImgResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/response/BoardImgResponseDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record BoardImgResponseDto(
-        String imgUrl,
-        Integer imgOrder
+
+        Integer imgOrder,
+        String imgUrl
 ){}

--- a/src/main/java/com/weady/weady/domain/board/dto/response/BoardResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/board/dto/response/BoardResponseDto.java
@@ -20,13 +20,15 @@ public record BoardResponseDto(
         List<BoardImgResponseDto> imageDtoList,
         String content,
 
-        Long weatherTagId,
-        Long temperatureTagId,
-        Long seasonTagId,
+
+        Long seasonTagId,  // 계절
+        Long temperatureTagId,  // 기온
+        Long weatherTagId,  // 날씨
 
         List<BoardPlaceResponseDto> placeDtoList,
         List<Long> styleIdList,
-        // List<Long> brandId,
+        List<BoardBrandResponseDto> brandDtoList,
 
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ){}

--- a/src/main/java/com/weady/weady/domain/board/entity/board/Board.java
+++ b/src/main/java/com/weady/weady/domain/board/entity/board/Board.java
@@ -7,7 +7,11 @@ import com.weady.weady.domain.user.entity.User;
 import com.weady.weady.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -72,10 +76,21 @@ public class Board extends BaseEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardStyle> boardStyleList = new ArrayList<>();
 
+    // 옷 정보
+    @Builder.Default
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoardBrand> boardBrandList = new ArrayList<>();
+
+
     // 좋아요
     @Builder.Default
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardGood> boardGoodList = new ArrayList<>();
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
 
     public void updateBoard(Boolean isPublic, String content, SeasonTag seasonTag,
                             TemperatureTag temperatureTag, WeatherTag weatherTag, Integer imgCount) {
@@ -109,6 +124,13 @@ public class Board extends BaseEntity {
 
         this.boardImgList.clear();
         this.boardImgList.addAll(boardImgList);
+    }
+
+    public void updateBoardBrandList(List<BoardBrand> boardBrandList){
+        boardBrandList.forEach(boardBrand -> {boardBrand.setBoard(this);});
+
+        this.boardBrandList.clear();
+        this.boardBrandList.addAll(boardBrandList);
     }
 
     public void increaseGoodCount() {

--- a/src/main/java/com/weady/weady/domain/board/entity/board/BoardBrand.java
+++ b/src/main/java/com/weady/weady/domain/board/entity/board/BoardBrand.java
@@ -1,0 +1,28 @@
+package com.weady.weady.domain.board.entity.board;
+
+
+import com.weady.weady.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class BoardBrand extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String brand;
+
+    private String product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    @Setter
+    private Board board;
+
+}

--- a/src/main/java/com/weady/weady/domain/board/entity/board/ReportType.java
+++ b/src/main/java/com/weady/weady/domain/board/entity/board/ReportType.java
@@ -9,7 +9,7 @@ public enum ReportType {
     Disinformation ("잘못된 정보"),
     Hate_Activity ("혐오 활동"),
     Offensive_Content ("모욕적인 내용"),
-    Illegal_Photo ("붋법 촬영물"),
+    Illegal_Photo ("불법 촬영물"),
     Other ("기타");
 
     private final String description;

--- a/src/main/java/com/weady/weady/domain/board/mapper/BoardMapper.java
+++ b/src/main/java/com/weady/weady/domain/board/mapper/BoardMapper.java
@@ -1,5 +1,6 @@
 package com.weady.weady.domain.board.mapper;
 
+import com.weady.weady.domain.board.dto.request.BoardBrandRequestDto;
 import com.weady.weady.domain.board.dto.request.BoardCreateRequestDto;
 import com.weady.weady.domain.board.dto.request.BoardPlaceRequestDto;
 import com.weady.weady.domain.board.dto.response.*;
@@ -57,6 +58,15 @@ public class BoardMapper {
                 .collect(Collectors.toList());
     }
 
+    public static List<BoardBrand> toBoardBrandList(List<BoardBrandRequestDto> requestDtos) {
+        return requestDtos.stream()
+                .map(dto -> BoardBrand.builder()
+                        .brand(dto.brand())
+                        .product(dto.product())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
     public static BoardGood toBoardGood(Board board, User user) {
         return BoardGood.builder()
                 .board(board)
@@ -93,21 +103,26 @@ public class BoardMapper {
 
         return BoardResponseDto.builder()
                 .boardId(board.getId())
-                .isPublic(board.getIsPublic())
-                .goodStatus(goodStatus)
-                .content(board.getContent())
-                .weatherTagId(board.getWeatherTag().getId())
-                .temperatureTagId(board.getTemperatureTag().getId())
-                .seasonTagId(board.getSeasonTag().getId())
                 .userId(user.getId())
                 .userName(user.getName())
                 .userProfileImageUrl(user.getProfileImageUrl())
-                .goodCount(board.getGoodCount())
-                .placeDtoList(toBoardPlaceResponseListDto(board.getBoardPlaceList()))
-                .imgCount(board.getImgCount())
-                .imageDtoList(toBoardImgResponseListDto(board.getBoardImgList()))
-                .styleIdList(styleIdList)
+
+                .isPublic(board.getIsPublic()) // 게시 여부
+                .goodStatus(goodStatus) // 현재 로그인 한 사용자가 해당 게시물에 좋아요를 눌렀는지 여부
+                .goodCount(board.getGoodCount())    // 좋아요 개수
+                .content(board.getContent()) // 내용
+
+                .weatherTagId(board.getWeatherTag().getId())
+                .temperatureTagId(board.getTemperatureTag().getId())
+                .seasonTagId(board.getSeasonTag().getId())
+
+                .placeDtoList(toBoardPlaceResponseListDto(board.getBoardPlaceList())) //장소
+                .imgCount(board.getImgCount())  // 이미지 개수
+                .imageDtoList(toBoardImgResponseListDto(board.getBoardImgList())) // 이미지
+                .styleIdList(styleIdList)  // 스타일 태그
+                .brandDtoList(toBoardBrandResponseListDto(board.getBoardBrandList())) // 옷 정보
                 .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
                 .build();
     }
 
@@ -127,6 +142,15 @@ public class BoardMapper {
                 .map(image -> BoardImgResponseDto.builder()
                         .imgOrder(image.getImgOrder())
                         .imgUrl(image.getImgUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public static List<BoardBrandResponseDto> toBoardBrandResponseListDto(List<BoardBrand> brands){
+        return brands.stream()
+                .map(brand -> BoardBrandResponseDto.builder()
+                        .brand(brand.getBrand())
+                        .product(brand.getProduct())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/weady/weady/domain/board/service/BoardService.java
+++ b/src/main/java/com/weady/weady/domain/board/service/BoardService.java
@@ -122,6 +122,7 @@ public class BoardService {
         board.updateBoardPlaceList(BoardMapper.toBoardPlaceList(postData.boardPlaceRequestDtoList()));
         board.updateBoardStyleList(BoardMapper.toBoardStyleList(categories));
         board.updateBoardImgList(BoardMapper.toBoardImgList(imageUrls, board));
+        board.updateBoardBrandList(BoardMapper.toBoardBrandList(postData.boardBrandRequestDtoList()));
 
         boardRepository.save(board);
 
@@ -168,6 +169,7 @@ public class BoardService {
         board.updateBoardPlaceList(BoardMapper.toBoardPlaceList(requestDto.boardPlaceRequestDtoList()));
         board.updateBoardStyleList(BoardMapper.toBoardStyleList(categories));
         board.updateBoardImgList(BoardMapper.toBoardImgList(imageUrls, board));
+        board.updateBoardBrandList(BoardMapper.toBoardBrandList(requestDto.boardBrandRequestDtoList()));
 
         boolean goodStatus = boardGoodRepository.existsByBoardAndUser(board, boardUser);
 

--- a/src/main/java/com/weady/weady/domain/board/service/BoardService.java
+++ b/src/main/java/com/weady/weady/domain/board/service/BoardService.java
@@ -78,9 +78,7 @@ public class BoardService {
     public BoardResponseDto getPostById(Long boardId) {
 
         Board board = getBoardById(boardId);
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
+        User user = getAuthenticatedUser();
 
         boolean goodStatus = boardGoodRepository.existsByBoardAndUser(board, user);
 
@@ -95,9 +93,7 @@ public class BoardService {
     @Transactional
     public BoardResponseDto createPost(List<MultipartFile> images, BoardCreateRequestDto postData) {
 
-        // 게시글 작성자 정보 조회
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User user = getAuthenticatedUser();
 
         // 날씨 태그 조회
         SeasonTag seasonTag = seasonRepository.findById(postData.seasonTagId())
@@ -141,9 +137,9 @@ public class BoardService {
         Board board = getBoardById(boardId);
         User boardUser = board.getUser(); // 작성자
 
-        Long userId = SecurityUtil.getCurrentUserId(); // 현재 로그인 한 사용자
+        User user = getAuthenticatedUser();
 
-        if (!userId.equals(boardUser.getId())){
+        if (!user.equals(boardUser)) {
             throw new BusinessException(BoardErrorCode.UNAUTHORIZED_UPDATE);
         }
 
@@ -185,10 +181,11 @@ public class BoardService {
     public void deletePost(Long boardId) {
 
         Board board = getBoardById(boardId);
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(()-> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        if (board.getUser().equals(user)) {
+        User boardUser = board.getUser();
+        User user = getAuthenticatedUser();
+
+        if (boardUser.equals(user)) {
             boardRepository.delete(board);
             return;
         }
@@ -206,8 +203,7 @@ public class BoardService {
     public BoardGoodResponseDto addGood(Long boardId) {
 
         // 좋아요 누르는 유저 정보
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User user = getAuthenticatedUser();
 
         Board board = getBoardById(boardId);
 
@@ -235,8 +231,7 @@ public class BoardService {
     public BoardGoodResponseDto cancelGood(Long boardId){
 
         // 좋아요 누르는 유저 정보
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User user = getAuthenticatedUser();
 
         Board board = getBoardById(boardId);
 
@@ -261,8 +256,7 @@ public class BoardService {
     public void reportPost(Long boardId, ReportRequestDto requestDto) {
 
         // 신고하는 유저 정보
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User user = getAuthenticatedUser();
 
         Board board = getBoardById(boardId);
 
@@ -272,7 +266,7 @@ public class BoardService {
             throw new BusinessException(BoardErrorCode.ALREADY_REPORTED);
         }
 
-        Report report = BoardMapper.toReport(board, user, requestDto.reportType(), requestDto.content());
+        Report report = BoardMapper.toReport(board, user, reportType, requestDto.content());
         reportRepository.save(report);
 
         // 게시물 신고 시, 신고자에게는 해당 게시물 숨김 처리
@@ -288,8 +282,7 @@ public class BoardService {
     @Transactional
     public void hidePost(Long boardId) {
 
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User user = getAuthenticatedUser();
 
         Board board = getBoardById(boardId);
 
@@ -309,8 +302,7 @@ public class BoardService {
     @Transactional
     public void unhidePost(Long boardId){
 
-        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        User user = getAuthenticatedUser();
 
         Board board = getBoardById(boardId);
 
@@ -321,9 +313,16 @@ public class BoardService {
     }
 
 
-    public Board getBoardById(Long boardId) {
+    private Board getBoardById(Long boardId) {
         return boardRepository.findById(boardId)
                 .orElseThrow(() -> new BusinessException(BoardErrorCode.BOARD_NOT_FOUND));
     }
+
+    private User getAuthenticatedUser() {
+        return userRepository.findById(SecurityUtil.getCurrentUserId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    }
+
 }
 

--- a/src/main/java/com/weady/weady/domain/weather/controller/WeatherController.java
+++ b/src/main/java/com/weady/weady/domain/weather/controller/WeatherController.java
@@ -5,6 +5,7 @@ import com.weady.weady.common.apiResponse.ApiSuccessResponse;
 import com.weady.weady.common.util.ResponseEntityUtil;
 import com.weady.weady.domain.weather.dto.response.GetLocationWeatherShortDetailResponse;
 import com.weady.weady.domain.weather.dto.response.GetWeatherMidDetailResponse;
+import com.weady.weady.domain.weather.dto.response.LocationTagResponseDto;
 import com.weady.weady.domain.weather.service.WeatherService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -52,5 +53,13 @@ public class WeatherController {
         ApiResponse<List<GetWeatherMidDetailResponse>> responseWrapper = ApiSuccessResponse.of(responseData,"중기 예보 조회에 성공했습니다.");
 
         return ResponseEntityUtil.buildDefaultResponseEntity(responseWrapper);
+    }
+
+    @GetMapping("/daily-summary")
+    @Operation(summary = "현재 위치의 계절, 기온, 날씨 태그 조회 API")
+    public ResponseEntity<ApiResponse<LocationTagResponseDto>> getLocationTag() {
+
+        LocationTagResponseDto responseDto = weatherService.getLocationTag();
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(responseDto));
     }
 }

--- a/src/main/java/com/weady/weady/domain/weather/dto/response/LocationTagResponseDto.java
+++ b/src/main/java/com/weady/weady/domain/weather/dto/response/LocationTagResponseDto.java
@@ -1,0 +1,9 @@
+package com.weady.weady.domain.weather.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record LocationTagResponseDto(Long seasonTagId,
+                                     Long temperatureTagId,
+                                     Long weatherTagId) {
+}

--- a/src/main/java/com/weady/weady/domain/weather/mapper/WeatherMapper.java
+++ b/src/main/java/com/weady/weady/domain/weather/mapper/WeatherMapper.java
@@ -3,6 +3,7 @@ package com.weady.weady.domain.weather.mapper;
 import com.weady.weady.domain.location.entity.Location;
 import com.weady.weady.domain.weather.dto.response.GetLocationWeatherShortDetailResponse;
 import com.weady.weady.domain.weather.dto.response.GetWeatherMidDetailResponse;
+import com.weady.weady.domain.weather.dto.response.LocationTagResponseDto;
 import com.weady.weady.domain.weather.entity.DailySummary;
 import com.weady.weady.domain.weather.entity.LocationWeatherShortDetail;
 import com.weady.weady.domain.weather.entity.WeatherMidDetail;
@@ -71,6 +72,15 @@ public class WeatherMapper {
                 .pmSkyStatus(weatherMid.getPmSkyCode())
                 .minTemp(weatherMid.getTmn())
                 .maxTemp(weatherMid.getTmx())
+                .build();
+    }
+
+    public static LocationTagResponseDto toLocationTagResponse(DailySummary dailySummary) {
+
+        return LocationTagResponseDto.builder()
+                .seasonTagId(dailySummary.getSeasonTag().getId())
+                .temperatureTagId(dailySummary.getTemperatureTag().getId())
+                .weatherTagId(dailySummary.getWeatherTag().getId())
                 .build();
     }
 

--- a/src/main/java/com/weady/weady/domain/weather/service/WeatherService.java
+++ b/src/main/java/com/weady/weady/domain/weather/service/WeatherService.java
@@ -137,10 +137,15 @@ public class WeatherService {
      */
     public LocationTagResponseDto getLocationTag() {
 
-        Location location = getLocationForWeatherQuery();
+        User user = getAuthenticatedUser();
+
+        Location nowLocation = user.getNowLocation();
+        if (nowLocation == null)
+            throw new BusinessException(LocationErrorCode.NOW_LOCATION_NOT_FOUND);
+
         LocalDate today = LocalDate.now();
 
-        DailySummary dailySummary = dailySummaryRepository.findByLocationIdAndReportDateWithTags(location.getId(), today)
+        DailySummary dailySummary = dailySummaryRepository.findByLocationIdAndReportDateWithTags(nowLocation.getId(), today)
                 .orElseThrow(() -> new BusinessException(DailySummaryErrorCode.DAILY_SUMMARY_NOT_FOUND));
 
         return WeatherMapper.toLocationTagResponse(dailySummary);


### PR DESCRIPTION
## #️⃣연관된 이슈

#105 
## 📝작업 내용

게시물 작성 시 옷 정보를 저장하는 기능을 구현했습니다. 프론트에서 브랜드, 제품명을 입력 받아 저장합니다.

현재 위치 기준으로 날씨 정보를 저장하기 위해, weather 도메인에 현재 위치를 기준으로 daily_summary에서 계절, 기온, 날씨 태그 Id를 가져오는 API를 구현했습니다. 
(게시물 작성 시, 사용자가 수동으로 날씨 태그를 선택하는 경우에도 현재 위치의 날씨 데이터가 표시되어야 하므로 게시물 작성 API와 분리했습니다!)
게시물 작성 테스트 시 프론트엔드에서 해당 API로부터 반환된 각 태그 ID를 받아 게시물 작성 요청에 포함합니다.
