### PR TITLE
[FEAT] Scheduler / 단기예보 스케쥴러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,15 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	// WebClient 사용을 위한 WebFlux 의존성
 	implementation 'org.springframework:spring-webflux'
+	implementation 'io.projectreactor.netty:reactor-netty-http'
+	runtimeOnly "io.netty:netty-resolver-dns-native-macos:4.1.110.Final:osx-aarch_64"
+
 
 	//S3
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.734'
 	implementation 'net.coobird:thumbnailator:0.4.19' // 이미지 리사이징, 썸네일 처리
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/weady/weady/WeadyApplication.java
+++ b/src/main/java/com/weady/weady/WeadyApplication.java
@@ -4,10 +4,12 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableJpaAuditing(modifyOnCreate = false)
 public class WeadyApplication {
 

--- a/src/main/java/com/weady/weady/common/config/SchedulerConfig.java
+++ b/src/main/java/com/weady/weady/common/config/SchedulerConfig.java
@@ -1,0 +1,32 @@
+package com.weady.weady.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class SchedulerConfig {
+
+    @Value("${scheduler.thread-pool.core-size}")
+    private int corePoolSize;
+    @Value("${scheduler.thread-pool.max-size}")
+    private int maxPoolSize;
+    @Value("${scheduler.thread-pool.queue-capacity}")
+    private int queueCapacity;
+
+    @Bean(name = "weatherTaskExecutor")
+    public Executor weatherTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("Weather-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/weady/weady/common/config/SwaggerConfig.java
+++ b/src/main/java/com/weady/weady/common/config/SwaggerConfig.java
@@ -28,8 +28,8 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(apiInfo())
                 .addSecurityItem(securityRequirement)
-                .components(components)
-                .addServersItem(new Server().url("https://weadyapi.pro"));  // ✅ 이거 추가!
+                .components(components);
+//                .addServersItem(new Server().url("https://weadyapi.pro"));  // ✅ 이거 추가!
     }
 
     private Info apiInfo() {

--- a/src/main/java/com/weady/weady/common/config/WebClientConfig.java
+++ b/src/main/java/com/weady/weady/common/config/WebClientConfig.java
@@ -1,0 +1,44 @@
+package com.weady.weady.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean(name = "kmaWebClient")
+    public WebClient kmaWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                // macOS DNS/IPv6 삽질 방지 (IPv4 우선 경로)
+                .resolver(DefaultAddressResolverGroup.INSTANCE)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(10))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(10))
+                        .addHandlerLast(new WriteTimeoutHandler(10)));
+
+        return WebClient.builder()
+                .baseUrl("https://apis.data.go.kr")
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.USER_AGENT, "Mozilla/5.0 (compatible; WeadyWeather/1.0)")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .exchangeStrategies(
+                        ExchangeStrategies.builder()
+                                .codecs(c -> c.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                                .build()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/weady/weady/common/config/WebClientConfig.java
+++ b/src/main/java/com/weady/weady/common/config/WebClientConfig.java
@@ -1,20 +1,27 @@
-package com.weady.weady.config;
+package com.weady.weady.common.config;
 
 import io.netty.channel.ChannelOption;
+import io.netty.handler.logging.LogLevel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.resolver.DefaultAddressResolverGroup;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
+@Slf4j
 @Configuration
 public class WebClientConfig {
 
@@ -27,18 +34,38 @@ public class WebClientConfig {
                 .responseTimeout(Duration.ofSeconds(10))
                 .doOnConnected(conn -> conn
                         .addHandlerLast(new ReadTimeoutHandler(10))
-                        .addHandlerLast(new WriteTimeoutHandler(10)));
+                        .addHandlerLast(new WriteTimeoutHandler(10)))
+                // ✅ 요청/응답 라인+헤더 로깅 (TEXTUAL)
+                .wiretap("reactor.netty.http.client", LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL);
 
         return WebClient.builder()
                 .baseUrl("https://apis.data.go.kr")
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .defaultHeader(HttpHeaders.USER_AGENT, "Mozilla/5.0 (compatible; WeadyWeather/1.0)")
                 .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name())
                 .exchangeStrategies(
                         ExchangeStrategies.builder()
                                 .codecs(c -> c.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
                                 .build()
                 )
+                // ✅ 요청/응답 간단 로그(최종 URL과 상태코드 확인용)
+                .filter(logRequest())
+                .filter(logResponse())
                 .build();
+    }
+
+    private static ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(req -> {
+            log.debug("HTTP {} {}", req.method(), req.url());
+            return Mono.just(req);
+        });
+    }
+
+    private static ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(res -> {
+            log.debug("HTTP <- {}", res.statusCode());
+            return Mono.just(res);
+        });
     }
 }

--- a/src/main/java/com/weady/weady/common/constant/WeatherApiProperties.java
+++ b/src/main/java/com/weady/weady/common/constant/WeatherApiProperties.java
@@ -1,0 +1,15 @@
+package com.weady.weady.common.constant;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kma.api")
+public class WeatherApiProperties {
+    private String shortTermKey;
+    private String baseUrl;
+}

--- a/src/main/java/com/weady/weady/common/error/errorCode/KMAErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/KMAErrorCode.java
@@ -1,0 +1,16 @@
+package com.weady.weady.common.error.errorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum KMAErrorCode implements ErrorCode {
+    RATE_LIMIT_EXCEEDED(429, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+    SERVICE_KEY_NOT_FOUND(404, "서비스 키를 찾을 수 없습니다."),
+    KMA_XML_ERROR(500, "KMA XML 응답에 오류가 발생했습니다."),
+    ;
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/weady/weady/domain/location/entity/Location.java
+++ b/src/main/java/com/weady/weady/domain/location/entity/Location.java
@@ -34,7 +34,7 @@ public class Location extends BaseEntity {
     private String midTermRegCode;
 
 
-    @OneToOne(mappedBy = "location")
-    private CurationCategory curationCategory;
+//    @OneToOne(mappedBy = "location")
+//    private CurationCategory curationCategory;
 
 }

--- a/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
+++ b/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
@@ -1,0 +1,31 @@
+package com.weady.weady.domain.scheduler;
+
+import com.weady.weady.domain.scheduler.service.WeatherUpdateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WeatherScheduler {
+
+    private final WeatherUpdateService weatherUpdateService;
+
+    /**
+     * 단기예보 스케쥴러
+     * 매일 02:10, 05:10, 08:10, 11:10, 14:10, 17:10, 20:10, 23:10 실행
+     * 기상청 API가 보통 10분~15분 뒤에 데이터를 제공하므로 10분에 실행
+     */
+    @Scheduled(cron = "0 10 2,5,8,11,14,17,20,23 * * *")
+    public void updateShortTermWeather() {
+        log.info("[WeatherScheduler] 단기예보 업데이트 시작");
+        try {
+            weatherUpdateService.updateShortTermWeather();
+        } catch (Exception e) {
+            log.error("[WeatherScheduler] 단기예보 업데이트 중 예외 발생", e);
+        }
+        log.info("[WeatherScheduler] 단기예보 업데이트 종료");
+    }
+}

--- a/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
+++ b/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
@@ -13,12 +13,8 @@ public class WeatherScheduler {
 
     private final WeatherUpdateService weatherUpdateService;
 
-    /**
-     * 단기예보 스케쥴러
-     * 매일 02:10, 05:10, 08:10, 11:10, 14:10, 17:10, 20:10, 23:10 실행
-     * 기상청 API가 보통 10분~15분 뒤에 데이터를 제공하므로 10분에 실행
-     */
-    @Scheduled(cron = "0 10 2,5,8,11,14,17,20,23 * * *")
+    // 매일 02:15, 05:15, 08:15, 11:15, 14:15, 17:15, 20:15, 23:15
+    @Scheduled(cron = "0 17 2,5,8,11,14,17,20,23 * * *", zone = "Asia/Seoul")
     public void updateShortTermWeather() {
         log.info("[WeatherScheduler] 단기예보 업데이트 시작");
         try {

--- a/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
+++ b/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
@@ -14,7 +14,7 @@ public class WeatherScheduler {
     private final WeatherUpdateService weatherUpdateService;
 
     // 매일 02:15, 05:15, 08:15, 11:15, 14:15, 17:15, 20:15, 23:15
-    @Scheduled(cron = "0 17 2,5,8,11,14,17,20,23 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 23 15,2,5,8,11,14,17,20,23 * * *", zone = "Asia/Seoul")
     public void updateShortTermWeather() {
         log.info("[WeatherScheduler] 단기예보 업데이트 시작");
         try {

--- a/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
+++ b/src/main/java/com/weady/weady/domain/scheduler/WeatherScheduler.java
@@ -14,7 +14,7 @@ public class WeatherScheduler {
     private final WeatherUpdateService weatherUpdateService;
 
     // 매일 02:15, 05:15, 08:15, 11:15, 14:15, 17:15, 20:15, 23:15
-    @Scheduled(cron = "0 23 15,2,5,8,11,14,17,20,23 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 15 11,23 * * *", zone = "Asia/Seoul")
     public void updateShortTermWeather() {
         log.info("[WeatherScheduler] 단기예보 업데이트 시작");
         try {

--- a/src/main/java/com/weady/weady/domain/scheduler/service/WeatherUpdateService.java
+++ b/src/main/java/com/weady/weady/domain/scheduler/service/WeatherUpdateService.java
@@ -310,42 +310,6 @@ public class WeatherUpdateService {
         });
     }
 
-    private void saveWeatherForecasts(Map<String, LocationWeatherShortDetail> newForecastsMap,
-                                      List<Location> locations,
-                                      BaseDateTime baseDateTime) {
-        List<Long> locationIds = locations.stream().map(Location::getId).collect(Collectors.toList());
-        int observationDate = Integer.parseInt(baseDateTime.baseDate);
-
-        List<LocationWeatherShortDetail> existingRecords = weatherRepository.findExistingRecords(locationIds, observationDate);
-        Map<String, LocationWeatherShortDetail> existingRecordsMap = existingRecords.stream()
-                .collect(Collectors.toMap(
-                        r -> r.getLocation().getId() + "-" + r.getDate() + "-" + r.getTime(),
-                        r -> r
-                ));
-
-        List<LocationWeatherShortDetail> toInsert = new ArrayList<>();
-        List<LocationWeatherShortDetail> toUpdate = new ArrayList<>();
-
-        newForecastsMap.forEach((key, newRecord) -> {
-            if (existingRecordsMap.containsKey(key)) {
-                LocationWeatherShortDetail existingRecord = existingRecordsMap.get(key);
-                updateEntity(existingRecord, newRecord);
-                toUpdate.add(existingRecord);
-            } else {
-                toInsert.add(newRecord);
-            }
-        });
-
-        if (!toInsert.isEmpty()) {
-            weatherRepository.saveAll(toInsert);
-            log.info("{} 건의 새로운 단기예보 데이터 추가", toInsert.size());
-        }
-        if (!toUpdate.isEmpty()) {
-            weatherRepository.saveAll(toUpdate);
-            log.info("{} 건의 단기예보 데이터 업데이트", toUpdate.size());
-        }
-    }
-
     private void updateEntity(LocationWeatherShortDetail oldEntity, LocationWeatherShortDetail newEntity) {
         oldEntity.setTmp(newEntity.getTmp());
         oldEntity.setWsd(newEntity.getWsd());

--- a/src/main/java/com/weady/weady/domain/scheduler/service/WeatherUpdateService.java
+++ b/src/main/java/com/weady/weady/domain/scheduler/service/WeatherUpdateService.java
@@ -1,0 +1,26 @@
+package com.weady.weady.domain.scheduler.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weady.weady.common.constant.WeatherApiProperties;
+import com.weady.weady.domain.location.repository.LocationRepository;
+import com.weady.weady.domain.weather.repository.WeatherShortDetailRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherUpdateService {
+
+    private final LocationRepository locationRepository;
+    private final WeatherShortDetailRepository weatherRepository;
+    private final WeatherApiProperties apiProperties;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    public void updateShortTermWeather() {}
+}

--- a/src/main/java/com/weady/weady/domain/weather/entity/LocationWeatherShortDetail.java
+++ b/src/main/java/com/weady/weady/domain/weather/entity/LocationWeatherShortDetail.java
@@ -10,6 +10,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Setter
 public class LocationWeatherShortDetail extends BaseEntity {
 
     @Id

--- a/src/main/java/com/weady/weady/domain/weather/entity/SkyCode.java
+++ b/src/main/java/com/weady/weady/domain/weather/entity/SkyCode.java
@@ -4,14 +4,39 @@ import lombok.Getter;
 
 @Getter
 public enum SkyCode {
-    CLEAR("맑음"),
-    PARTLY_CLOUDY("구름많음"),
-    CLOUDY("흐림"),
-    RAIN("비"),
-    SNOW("눈"),
+    CLEAR("맑음"),          // SKY: 1
+    PARTLY_CLOUDY("구름많음"), // SKY: 3
+    CLOUDY("흐림"),         // SKY: 4
+    RAIN("비"),             // PTY: 1, 2, 5
+    SNOW("눈"),             // PTY: 3, 6, 7
     ;
     private final String description;
     SkyCode(String description) {
         this.description = description;
+    }
+
+    /**
+     * 기상청 API 의 PTY(강수형태), SKY(하늘상태) 코드를 내부 SkyCode 로 변환
+     * @param ptyCode 강수형태 코드 (0: 없음, 1: 비, 2: 비/눈, 3: 눈, 5: 빗방울, 6: 빗방울/눈날림, 7: 눈날림)
+     * @param skyCode 하늘상태 코드 (1: 맑음, 3: 구름많음, 4: 흐림)
+     * @return 매핑된 SkyCode
+     */
+    public static SkyCode fromKmaCodes(String ptyCode, String skyCode) {
+        // 강수형태(PTY)가 우선순위가 높다.
+        return switch (ptyCode) {
+            case "1", "2", "5" -> RAIN;
+            case "3", "6", "7" -> SNOW;
+            default ->
+
+                // 강수형태가 '없음(0)'일 경우, 하늘상태(SKY)로 판단한다.
+                    switch (skyCode) {
+                        case "1" -> CLEAR;
+                        case "3" -> PARTLY_CLOUDY;
+                        case "4" -> CLOUDY;
+                        default ->
+                                null;
+                    };
+        };
+
     }
 }

--- a/src/main/java/com/weady/weady/domain/weather/repository/WeatherShortDetailRepository.java
+++ b/src/main/java/com/weady/weady/domain/weather/repository/WeatherShortDetailRepository.java
@@ -2,6 +2,7 @@ package com.weady.weady.domain.weather.repository;
 
 import com.weady.weady.domain.weather.entity.LocationWeatherShortDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -22,4 +23,20 @@ public interface WeatherShortDetailRepository extends JpaRepository<LocationWeat
             @Param("locationId") Long locationId,
             @Param("todayDate") LocalDate todayDate
     );
+
+    // 지난 레코드 삭제를 위한 쿼리
+    @Modifying
+    @Query("DELETE FROM LocationWeatherShortDetail lwsd " +
+            "WHERE lwsd.observationDate < :date " +
+            "OR (lwsd.observationDate = :date " +
+            "AND lwsd.observationTime < :time)")
+    void deleteOldRecords(@Param("date") int date, @Param("time") int time);
+
+    // 효율적인 UPSERT 를 위해 특정 시간대의 기존 레코드를 미리 조회
+    @Query("SELECT lwsd " +
+            "FROM LocationWeatherShortDetail lwsd " +
+            "WHERE lwsd.location.id IN :locationIds " +
+            "AND lwsd.observationDate = :observationDate")
+    List<LocationWeatherShortDetail> findExistingRecords(@Param("locationIds") List<Long> locationIds, @Param("observationDate") int observationDate);
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 

## 📝작업 내용

Location의 Nx ny를 기준으로 단기예보를 가져오는 스케쥴러를 구현합니다.
호출간 텀은 600ms , 동시에 3개의 그리드를 처리하고 group insert를 통해 성능을 개선시켰습니다.