### PR TITLE
[FEAT] MyPage / 프로필 이미지 업로드 s3 연동 및 닉네임 중복 검증 추가

### DIFF
--- a/src/main/java/com/weady/weady/common/error/errorCode/S3ErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/S3ErrorCode.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum S3ErrorCode implements ErrorCode {
     S3_UPLOAD_FAIL(500, "S3 업로드 실패"),
+    S3_REMOVE_FAIL(500, "S3 삭제 실패"),
     ;
 
     private final int code;

--- a/src/main/java/com/weady/weady/common/error/errorCode/UserErrorCode.java
+++ b/src/main/java/com/weady/weady/common/error/errorCode/UserErrorCode.java
@@ -10,7 +10,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(404, "해당 사용자를 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(409, "이미 존재하는 사용자입니다."),
     INVALID_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
-    USER_DEFAULT_LOCATION_NOT_FOUNT(404, "유저의 기본 위치를 알 수 없습니다")
+    USER_DEFAULT_LOCATION_NOT_FOUNT(404, "유저의 기본 위치를 알 수 없습니다"),
+    DUPLICATE_NAME(409, "이미 사용중인 닉네임입니다.")
     ;
 
 

--- a/src/main/java/com/weady/weady/common/external/s3/S3Remover.java
+++ b/src/main/java/com/weady/weady/common/external/s3/S3Remover.java
@@ -1,4 +1,50 @@
 package com.weady.weady.common.external.s3;
 
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.weady.weady.common.error.errorCode.S3ErrorCode;
+import com.weady.weady.common.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
 public class S3Remover {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public void remove(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            log.info("S3Remover: Skip delete - empty url.");
+            return;
+        }
+
+        final String key;
+        try {
+            String rawPath = URI.create(fileUrl).getRawPath();
+            if (rawPath == null || rawPath.length() <= 1) {
+                log.warn("S3Remover: Invalid url path. url={}", fileUrl);
+                return;
+            }
+            key = (rawPath.charAt(0) == '/') ? rawPath.substring(1) : rawPath;
+        } catch (Exception e) {
+            log.error("S3Remover: URL parse failed. url={}", fileUrl, e);
+            throw new BusinessException(S3ErrorCode.S3_REMOVE_FAIL);
+        }
+
+        try {
+            amazonS3.deleteObject(bucket, key);
+            log.info("S3Remover: Delete successful. bucket={}, key={}", bucket, key);
+        } catch (SdkClientException e) {
+            log.error("S3Remover: Delete failed. bucket={}, key={}", bucket, key, e);
+            throw new BusinessException(S3ErrorCode.S3_REMOVE_FAIL);
+        }
+    }
 }

--- a/src/main/java/com/weady/weady/common/external/s3/S3Remover.java
+++ b/src/main/java/com/weady/weady/common/external/s3/S3Remover.java
@@ -1,0 +1,4 @@
+package com.weady.weady.common.external.s3;
+
+public class S3Remover {
+}

--- a/src/main/java/com/weady/weady/domain/user/controller/UserController.java
+++ b/src/main/java/com/weady/weady/domain/user/controller/UserController.java
@@ -10,12 +10,16 @@ import com.weady.weady.common.apiResponse.ApiResponse;
 import com.weady.weady.common.apiResponse.ApiSuccessResponse;
 import com.weady.weady.common.util.ResponseEntityUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -46,9 +50,23 @@ public class UserController {
     }
 
     @Operation(summary = "프로필 편집 API", description = "마이페이지에서 프로필(닉네임, 이미지)을 수정합니다.")
-    @PatchMapping("/profile")
-    public ResponseEntity<ApiResponse<UpdateUserProfileResponse>> updateUserProfile(@RequestBody @Valid UpdateUserProfileRequest request) {
-        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(userService.updateUserProfile(request)));
+    @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<UpdateUserProfileResponse>> updateUserProfile(
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+            @Parameter(
+                    description = "이미지 파일을 제외한 프로필 수정 JSON",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            @RequestPart(value = "profileData") @Valid UpdateUserProfileRequest profileData) {
+
+        UpdateUserProfileResponse response = userService.updateUserProfile(profileData, profileImage);
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(response, "프로필 수정 성공!"));
+    }
+
+    @Operation(summary = "프로필 이미지 기본값 적용 API", description = "현재 사용자의 프로필 이미지를 기본값으로 되돌립니다.")
+    @DeleteMapping("/profile/image")
+    public ResponseEntity<ApiResponse<UpdateUserProfileResponse>> resetProfileImage() {
+        UpdateUserProfileResponse response = userService.resetProfileImage();
+        return ResponseEntityUtil.buildDefaultResponseEntity(ApiSuccessResponse.of(response, "프로필 이미지가 기본값으로 적용되었습니다."));
     }
 
     @Operation(summary = "마이페이지 조회 API", description = "마이페이지(닉네임, 프로필 이미지, 캘린더)를 조회합니다.")

--- a/src/main/java/com/weady/weady/domain/user/dto/request/UpdateUserProfileRequest.java
+++ b/src/main/java/com/weady/weady/domain/user/dto/request/UpdateUserProfileRequest.java
@@ -8,6 +8,4 @@ import jakarta.validation.constraints.Size;
 public record UpdateUserProfileRequest(
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
         @Size(min = 2, max = 15, message = "닉네임은 2자 이상 15자 이하로 입력해주세요.")
-        @Unique(entity = User.class, field = "name", message = "이미 사용 중인 닉네임입니다.")
-        String name,
-        String profileImageUrl) { }
+        String name) { }

--- a/src/main/java/com/weady/weady/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/weady/weady/domain/user/repository/UserRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndSocialId(Provider provider, String socialId);
     Optional<User> findByEmail(String email);
-
+    boolean existsByNameAndIdNot(String name, Long userId);
 }

--- a/src/main/java/com/weady/weady/domain/user/service/UserService.java
+++ b/src/main/java/com/weady/weady/domain/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.weady.weady.domain.user.service;
 
 import com.weady.weady.common.error.errorCode.LocationErrorCode;
 import com.weady.weady.common.external.kakao.KakaoRegionService;
+import com.weady.weady.common.external.s3.S3Remover;
+import com.weady.weady.common.external.s3.S3Uploader;
 import com.weady.weady.domain.location.entity.Location;
 import com.weady.weady.domain.location.repository.LocationRepository;
 import com.weady.weady.domain.tags.entity.ClothesStyleCategory;
@@ -26,6 +28,9 @@ import com.weady.weady.domain.user.repository.UserTermsAgreementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +43,8 @@ public class UserService {
     private final ClothesStyleCategoryRepository clothesStyleCategoryRepository;
     private final LocationRepository locationRepository;
     private final UserTermsAgreementRepository userTermsAgreementRepository;
+    private final S3Uploader s3Uploader;
+    private final S3Remover s3Remover;
 
     @Transactional
     public OnboardResponse onboard(OnboardRequest request){
@@ -72,12 +79,48 @@ public class UserService {
     }
 
     @Transactional
-    public UpdateUserProfileResponse updateUserProfile(UpdateUserProfileRequest request){
+    public UpdateUserProfileResponse updateUserProfile(UpdateUserProfileRequest request, MultipartFile profileImage){
         User user = userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        user.changeName(request.name());
-        user.changeProfileImageUrl(request.profileImageUrl());
+        String newName = request.name().trim();
+
+        // 닉네임이 바뀔 때, 나를 제외하고 중복 검사 ->
+        if (!newName.equals(user.getName())) {
+            if (userRepository.existsByNameAndIdNot(newName, user.getId())) {
+                throw new BusinessException(UserErrorCode.DUPLICATE_NAME);
+            }
+            user.changeName(request.name());
+        }
+
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String oldUrl = user.getProfileImageUrl();
+            String newUrl = s3Uploader.upload(profileImage, "profile");
+            user.changeProfileImageUrl(newUrl);
+
+            runAfterCommit(() -> {
+                if (oldUrl != null && !oldUrl.isBlank() && !oldUrl.equals(newUrl)) {
+                    s3Remover.remove(oldUrl);
+                }
+            });
+        }
+
+        return UserMapper.toUpdateUserProfileResponse(user);
+    }
+
+    @Transactional
+    public UpdateUserProfileResponse resetProfileImage() {
+        User user = userRepository.findById(SecurityUtil.getCurrentUserId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        String oldUrl = user.getProfileImageUrl();
+        user.changeProfileImageUrl(null);
+
+        runAfterCommit(() -> {
+            if (oldUrl != null && !oldUrl.isBlank()) {
+                s3Remover.remove(oldUrl);
+            }
+        });
 
         return UserMapper.toUpdateUserProfileResponse(user);
     }
@@ -91,5 +134,16 @@ public class UserService {
                 ? user.getDefaultLocation().getLocation() : user.getNowLocation();
 
         return UserMapper.toResponse(location);
+    }
+
+    // 트랜잭션 커밋 이후 작업 실행
+    private void runAfterCommit(Runnable task) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override public void afterCommit() { task.run(); }
+            });
+        } else {
+            task.run();
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#121 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
프로필 이미지 업로드 및 변경 시 s3 연동하였으며, 닉네임 중복 검증을 자기 자신은 제외하고 검증하는 것으로 수정하였습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
브랜치 이름을 fashion이라고 잘못판걸 이제 알았네용.......... ㅜㅜ

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?