### PR TITLE
[fix] User /  즐겨찾기 목록조회 버그와 기본위치변경 에러 수정

### DIFF
--- a/src/main/java/com/weady/weady/domain/user/entity/User.java
+++ b/src/main/java/com/weady/weady/domain/user/entity/User.java
@@ -29,7 +29,7 @@ public class User extends BaseEntity {
     private Location nowLocation;
 
     @Setter
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "default_location_id")
     private UserFavoriteLocation defaultLocation;
 

--- a/src/main/java/com/weady/weady/domain/user/repository/UserFavoriteLocationRepository.java
+++ b/src/main/java/com/weady/weady/domain/user/repository/UserFavoriteLocationRepository.java
@@ -17,22 +17,31 @@ public interface UserFavoriteLocationRepository extends JpaRepository<UserFavori
 
     List<UserFavoriteLocation> findByUser(User user);
 
-    /**
-     * --- [성능 최적화] ---
-     * 특정 사용자의 모든 즐겨찾기 정보를 관련 날씨/요약 데이터와 함께 한 번의 쿼리로 조회합니다.
-     * N+1 문제를 해결하기 위해 여러 엔티티를 LEFT JOIN으로 연결합니다.
-     *
-     * @param userId      조회할 사용자의 ID
-     * @param reportDate  조회할 일일 요약 정보의 날짜 (오늘)
-     * @param currentTime 조회할 현재 날씨 정보의 시간 (예: 1500)
-     * @return Object 배열의 리스트. 각 배열은 [UserFavoriteLocation, LocationWeatherShortDetail, DailySummary] 순서로 구성됩니다.
-     */
-    @Query("SELECT uf, lwsd, ds " +
-            "FROM UserFavoriteLocation uf " +
-            "JOIN FETCH uf.location l " +
-            "LEFT JOIN LocationWeatherShortDetail lwsd ON lwsd.location = l AND lwsd.time = :currentTime " +
-            "LEFT JOIN DailySummary ds ON ds.location = l AND ds.reportDate = :reportDate " +
-            "WHERE uf.user.id = :userId")
+
+    @Query("""
+select uf, lwsd, ds
+from UserFavoriteLocation uf
+join uf.location l
+left join LocationWeatherShortDetail lwsd
+       on lwsd.location = l
+      and lwsd.time = :currentTime
+      and lwsd.id = (
+           select max(s.id)
+           from LocationWeatherShortDetail s
+           where s.location = l
+             and s.time = :currentTime
+      )
+left join DailySummary ds
+       on ds.location = l
+      and ds.reportDate = :reportDate
+      and ds.id = (
+           select max(d2.id)
+           from DailySummary d2
+           where d2.location = l
+             and d2.reportDate = :reportDate
+      )
+where uf.user.id = :userId
+""")
     List<Object[]> findFavoritesWithDetailsByUserId(
             @Param("userId") Long userId,
             @Param("reportDate") LocalDate reportDate,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #137 

## 📝작업 내용

> JPQL 쿼리에서 카테시안 곱이 발생하면서 같은 조회 결과값이 중복 반환되는 버그를 쿼리문 수정을 통해 해결
> User엔티티의 잘못된 Cascade/orphanRemoval 설정으로 인해 발생한 기본위치 변경 문제를 엔티티 수정을 통해 해결
